### PR TITLE
mvfst-ubuntu1804: Enhanced error message for installing `gtest` in `build_helper.sh`

### DIFF
--- a/build_helper.sh
+++ b/build_helper.sh
@@ -173,9 +173,16 @@ function setup_googletest() {
     TMP_DIR=$(mktemp -d)
     pushd .
     cd "$TMP_DIR"
-    wget https://github.com/google/googletest/archive/release-1.8.0.zip -O "googletest.zip"
-    unzip "googletest.zip" -d "$DEPS_DIR"
-    popd
+    if wget https://github.com/google/googletest/archive/release-1.8.0.zip -O "googletest.zip"; then
+      unzip "googletest.zip" -d "$DEPS_DIR"
+      popd
+    else
+      echo -e "${COLOR_RED}[ INFO ] Googletest is a reqiured dependency${COLOR_OFF}"
+      echo -e "${COLOR_RED}[ INFO ] Cloning googletest from Github has failed.${COLOR_OFF}"
+      echo -e "${COLOR_RED}[ INFO ] Try downloading from Github and manually" \
+              "installing ${GTEST_DIR} and running again.${COLOR_OFF}"
+      exit
+    fi
   fi
   echo -e "${COLOR_GREEN}Building Googletest ${COLOR_OFF}"
   mkdir -p "$GTEST_BUILD_DIR"


### PR DESCRIPTION
On Ubuntu 18.04.2 I was receiving error messages when running `build_helper.sh` about verifying the cert for Github while trying to clone `gtest` into the `_build` directory.  I was not able to resolve the clone issue but I was able to download and manually install `googletest-release-1.8.0` into the `_build/deps` directory so cmake could find it.  So I thought it would be beneficial to add an error message to the `build_helper.sh` file:
![build_helper_error](https://user-images.githubusercontent.com/7466510/57181314-9e62dc80-6e57-11e9-92a7-ef0a1a805a27.png)

After manually installing `gtest` cmake was able to find it and start the build process.
![gtest_building](https://user-images.githubusercontent.com/7466510/57181321-b20e4300-6e57-11e9-80d9-7cf8016681db.png)
