### PR TITLE
ExternalProject: log to stdout instead of files

### DIFF
--- a/cmake/BuildFizz.cmake
+++ b/cmake/BuildFizz.cmake
@@ -26,12 +26,6 @@ ExternalProject_Add(
   SOURCE_SUBDIR fizz
   # Disable install step
   INSTALL_COMMAND ""
-  LOG_DOWNLOAD ON
-  LOG_UPDATE 1
-  LOG_CONFIGURE ON
-  LOG_BUILD ON
-  LOG_TEST 1
-  LOG_INSTALL 1
   CMAKE_CACHE_ARGS ${CMAKE_ARGS}
 )
 set(FIZZ_TARGET fizz_project)

--- a/cmake/QuicTest.cmake
+++ b/cmake/QuicTest.cmake
@@ -16,12 +16,6 @@ if(BUILD_TESTS)
     PREFIX googletest
     # Disable install step
     INSTALL_COMMAND ""
-    LOG_DOWNLOAD ON
-    LOG_UPDATE 1
-    LOG_CONFIGURE ON
-    LOG_BUILD ON
-    LOG_TEST 1
-    LOG_INSTALL 1
     CMAKE_CACHE_ARGS
       -DCMAKE_BUILD_TYPE:STRING=Release
       -DBUILD_GMOCK:BOOL=ON


### PR DESCRIPTION
If you specify the `LOG_*` directives, then nothing appears on stdout
while the external project is building.  On my Mac, this means it sits
at the Fizz build step for 4+ minutes with no visible progress in the
terminal.

Removing the `LOG_*` directives means that cmake will display all the
output to stdout instead of to files.  This is consistent with the
build behavior for Folly (which is not a cmake ExternalProject).  If
logging the external project builds is desired, the user can capture
the output of the build_helper.sh.

Signed-off-by: Jeff Squyres <jeff@squyres.com>