### PR TITLE
Add a bridge to fizz::Aead

### DIFF
--- a/quic/api/QuicTransportFunctions.cpp
+++ b/quic/api/QuicTransportFunctions.cpp
@@ -453,7 +453,7 @@ uint64_t writeQuicDataToSocket(
     QuicConnectionStateBase& connection,
     const ConnectionId& srcConnId,
     const ConnectionId& dstConnId,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     uint64_t packetLimit) {
@@ -527,7 +527,7 @@ uint64_t writeCryptoAndAckDataToSocket(
     const ConnectionId& srcConnId,
     const ConnectionId& dstConnId,
     LongHeader::Types packetType,
-    fizz::Aead& cleartextCipher,
+    Aead& cleartextCipher,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     uint64_t packetLimit,
@@ -572,7 +572,7 @@ uint64_t writeQuicDataExceptCryptoStreamToSocket(
     QuicConnectionStateBase& connection,
     const ConnectionId& srcConnId,
     const ConnectionId& dstConnId,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     uint64_t packetLimit) {
@@ -640,7 +640,7 @@ uint64_t writeZeroRttDataToSocket(
     QuicConnectionStateBase& connection,
     const ConnectionId& srcConnId,
     const ConnectionId& dstConnId,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     uint64_t packetLimit) {
@@ -688,7 +688,7 @@ void writeCloseCommon(
     QuicConnectionStateBase& connection,
     PacketHeader&& header,
     folly::Optional<std::pair<QuicErrorCode, std::string>> closeDetails,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher) {
   // close is special, we're going to bypass all the packet sent logic for all
   // packets we send with a connection close frame.
@@ -773,7 +773,7 @@ void writeLongClose(
     const ConnectionId& dstConnId,
     LongHeader::Types headerType,
     folly::Optional<std::pair<QuicErrorCode, std::string>> closeDetails,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version) {
   if (!connection.serverConnectionId) {
@@ -802,7 +802,7 @@ void writeShortClose(
     QuicConnectionStateBase& connection,
     const ConnectionId& connId,
     folly::Optional<std::pair<QuicErrorCode, std::string>> closeDetails,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher) {
   auto header = ShortHeader(
       ProtectionType::KeyPhaseZero,
@@ -858,7 +858,7 @@ uint64_t writeConnectionDataToSocket(
     QuicPacketScheduler& scheduler,
     const WritableBytesFunc& writableBytesFunc,
     uint64_t packetLimit,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     Buf token) {
@@ -961,7 +961,7 @@ uint64_t writeProbingDataToSocket(
     PacketNumberSpace pnSpace,
     FrameScheduler scheduler,
     uint8_t probesToSend,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version) {
   CloningScheduler cloningScheduler(

--- a/quic/api/QuicTransportFunctions.h
+++ b/quic/api/QuicTransportFunctions.h
@@ -39,7 +39,7 @@ uint64_t writeQuicDataToSocket(
     QuicConnectionStateBase& connection,
     const ConnectionId& srcConnId,
     const ConnectionId& dstConnId,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     uint64_t packetLimit);
@@ -55,7 +55,7 @@ uint64_t writeCryptoAndAckDataToSocket(
     const ConnectionId& srcConnId,
     const ConnectionId& dstConnId,
     LongHeader::Types packetType,
-    fizz::Aead& cleartextCipher,
+    Aead& cleartextCipher,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     uint64_t packetLimit,
@@ -71,7 +71,7 @@ uint64_t writeQuicDataExceptCryptoStreamToSocket(
     QuicConnectionStateBase& connection,
     const ConnectionId& srcConnId,
     const ConnectionId& dstConnId,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     uint64_t packetLimit);
@@ -85,7 +85,7 @@ uint64_t writeZeroRttDataToSocket(
     QuicConnectionStateBase& connection,
     const ConnectionId& srcConnId,
     const ConnectionId& dstConnId,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     uint64_t packetLimit);
@@ -154,7 +154,7 @@ void writeCloseCommon(
     QuicConnectionStateBase& connection,
     PacketHeader&& header,
     folly::Optional<std::pair<QuicErrorCode, std::string>> closeDetails,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher);
 
 /**
@@ -168,7 +168,7 @@ void writeLongClose(
     const ConnectionId& dstConnId,
     LongHeader::Types headerType,
     folly::Optional<std::pair<QuicErrorCode, std::string>> closeDetails,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion);
 
@@ -181,7 +181,7 @@ void writeShortClose(
     QuicConnectionStateBase& connection,
     const ConnectionId& connId,
     folly::Optional<std::pair<QuicErrorCode, std::string>> closeDetails,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher);
 
 /**
@@ -213,7 +213,7 @@ uint64_t writeConnectionDataToSocket(
     QuicPacketScheduler& scheduler,
     const WritableBytesFunc& writableBytesFunc,
     uint64_t packetLimit,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     Buf token = nullptr);
@@ -227,7 +227,7 @@ uint64_t writeProbingDataToSocket(
     PacketNumberSpace pnSpace,
     FrameScheduler scheduler,
     uint8_t probesToSend,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version);
 

--- a/quic/api/test/QuicTransportBaseTest.cpp
+++ b/quic/api/test/QuicTransportBaseTest.cpp
@@ -332,7 +332,7 @@ class TestQuicTransport
   }
 
   QuicServerConnectionState* transportConn;
-  std::unique_ptr<fizz::Aead> aead;
+  std::unique_ptr<Aead> aead;
   std::unique_ptr<PacketNumberCipher> headerCipher;
   std::unique_ptr<ConnectionIdAlgo> connIdAlgo_;
   bool transportClosed{false};

--- a/quic/api/test/QuicTransportFunctionsTest.cpp
+++ b/quic/api/test/QuicTransportFunctionsTest.cpp
@@ -28,7 +28,7 @@ uint64_t writeProbingDataToSocketForTest(
     folly::AsyncUDPSocket& sock,
     QuicConnectionStateBase& conn,
     uint8_t probesToSend,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version) {
   FrameScheduler scheduler = std::move(FrameScheduler::Builder(
@@ -57,7 +57,7 @@ void writeCryptoDataProbesToSocketForTest(
     folly::AsyncUDPSocket& sock,
     QuicConnectionStateBase& conn,
     uint8_t probesToSend,
-    const fizz::Aead& aead,
+    const Aead& aead,
     const PacketNumberCipher& headerCipher,
     QuicVersion version,
     LongHeader::Types type = LongHeader::Types::Initial) {
@@ -171,7 +171,7 @@ class QuicTransportFunctionsTest : public Test {
     return conn.version.value_or(*conn.originalVersion);
   }
 
-  std::unique_ptr<fizz::Aead> aead;
+  std::unique_ptr<Aead> aead;
   std::unique_ptr<PacketNumberCipher> headerCipher;
   std::unique_ptr<MockQuicStats> transportInfoCb_;
 };

--- a/quic/api/test/QuicTransportTest.cpp
+++ b/quic/api/test/QuicTransportTest.cpp
@@ -138,7 +138,7 @@ class TestQuicTransport
     drainTimeoutExpired();
   }
 
-  std::unique_ptr<fizz::Aead> aead;
+  std::unique_ptr<Aead> aead;
   std::unique_ptr<PacketNumberCipher> headerCipher;
   bool closed{false};
 };

--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -90,35 +90,35 @@ void ClientHandshake::doHandshake(
   }
 }
 
-std::unique_ptr<fizz::Aead> ClientHandshake::getOneRttWriteCipher() {
+std::unique_ptr<Aead> ClientHandshake::getOneRttWriteCipher() {
   if (error_) {
     error_.throw_exception();
   }
   return std::move(oneRttWriteCipher_);
 }
 
-std::unique_ptr<fizz::Aead> ClientHandshake::getOneRttReadCipher() {
+std::unique_ptr<Aead> ClientHandshake::getOneRttReadCipher() {
   if (error_) {
     error_.throw_exception();
   }
   return std::move(oneRttReadCipher_);
 }
 
-std::unique_ptr<fizz::Aead> ClientHandshake::getZeroRttWriteCipher() {
+std::unique_ptr<Aead> ClientHandshake::getZeroRttWriteCipher() {
   if (error_) {
     error_.throw_exception();
   }
   return std::move(zeroRttWriteCipher_);
 }
 
-std::unique_ptr<fizz::Aead> ClientHandshake::getHandshakeReadCipher() {
+std::unique_ptr<Aead> ClientHandshake::getHandshakeReadCipher() {
   if (error_) {
     error_.throw_exception();
   }
   return std::move(handshakeReadCipher_);
 }
 
-std::unique_ptr<fizz::Aead> ClientHandshake::getHandshakeWriteCipher() {
+std::unique_ptr<Aead> ClientHandshake::getHandshakeWriteCipher() {
   if (error_) {
     error_.throw_exception();
   }

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -65,31 +65,31 @@ class ClientHandshake : public Handshake {
    * An edge triggered API to get the oneRttWriteCipher. Once you receive the
    * write cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getOneRttWriteCipher();
+  std::unique_ptr<Aead> getOneRttWriteCipher();
 
   /**
    * An edge triggered API to get the oneRttReadCipher. Once you receive the
    * read cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getOneRttReadCipher();
+  std::unique_ptr<Aead> getOneRttReadCipher();
 
   /**
    * An edge triggered API to get the zeroRttWriteCipher. Once you receive the
    * zero rtt write cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getZeroRttWriteCipher();
+  std::unique_ptr<Aead> getZeroRttWriteCipher();
 
   /**
    * An edge triggered API to get the handshakeReadCipher. Once you
    * receive the handshake read cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getHandshakeReadCipher();
+  std::unique_ptr<Aead> getHandshakeReadCipher();
 
   /**
    * An edge triggered API to get the handshakeWriteCipher. Once you
    * receive the handshake write cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getHandshakeWriteCipher();
+  std::unique_ptr<Aead> getHandshakeWriteCipher();
 
   /**
    * An edge triggered API to get the one rtt read header cpher. Once you

--- a/quic/client/handshake/test/ClientHandshakeTest.cpp
+++ b/quic/client/handshake/test/ClientHandshakeTest.cpp
@@ -244,11 +244,11 @@ class ClientHandshakeTest : public Test, public boost::static_visitor<> {
   folly::IOBufQueue serverReadBuf{folly::IOBufQueue::cacheChainLength()};
   std::unique_ptr<DelayedHolder, folly::DelayedDestruction::Destructor> dg;
 
-  std::unique_ptr<fizz::Aead> handshakeWriteCipher;
-  std::unique_ptr<fizz::Aead> handshakeReadCipher;
-  std::unique_ptr<fizz::Aead> oneRttWriteCipher;
-  std::unique_ptr<fizz::Aead> oneRttReadCipher;
-  std::unique_ptr<fizz::Aead> zeroRttWriteCipher;
+  std::unique_ptr<Aead> handshakeWriteCipher;
+  std::unique_ptr<Aead> handshakeReadCipher;
+  std::unique_ptr<Aead> oneRttWriteCipher;
+  std::unique_ptr<Aead> oneRttReadCipher;
+  std::unique_ptr<Aead> zeroRttWriteCipher;
 
   folly::Optional<bool> zeroRttRejected;
 

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -1321,7 +1321,7 @@ class QuicClientTransportTest : public Test {
       bool handshakeCipher = false) {
     QuicFizzFactory fizzFactory;
     auto codec = std::make_unique<QuicReadCodec>(QuicNodeType::Server);
-    std::unique_ptr<fizz::Aead> handshakeReadCipher;
+    std::unique_ptr<Aead> handshakeReadCipher;
     codec->setClientConnectionId(*originalConnId);
     codec->setOneRttReadCipher(test::createNoOpAead());
     codec->setOneRttHeaderCipher(test::createNoOpHeaderCipher());
@@ -1338,7 +1338,7 @@ class QuicClientTransportTest : public Test {
     return codec;
   }
 
-  const fizz::Aead& getInitialCipher() {
+  const Aead& getInitialCipher() {
     return *client->getConn().readCodec->getInitialCipher();
   }
 
@@ -3441,7 +3441,7 @@ Buf getHandshakePacketWithFrame(
     QuicWriteFrame frame,
     ConnectionId srcConnId,
     ConnectionId destConnId,
-    const fizz::Aead& serverWriteCipher,
+    const Aead& serverWriteCipher,
     const PacketNumberCipher& headerCipher) {
   PacketNum packetNum = folly::Random::rand32();
   LongHeader header(

--- a/quic/codec/QuicReadCodec.cpp
+++ b/quic/codec/QuicReadCodec.cpp
@@ -104,7 +104,7 @@ CodecResult QuicReadCodec::parseLongHeaderPacket(
   }
   cursor.pull(sample.data(), sample.size());
   const PacketNumberCipher* headerCipher{nullptr};
-  const fizz::Aead* cipher{nullptr};
+  const Aead* cipher{nullptr};
   auto protectionType = longHeader.getProtectionType();
   switch (protectionType) {
     case ProtectionType::Initial:
@@ -334,15 +334,15 @@ CodecResult QuicReadCodec::parsePacket(
   return decodeRegularPacket(std::move(*shortHeader), params_, packetCursor);
 }
 
-const fizz::Aead* QuicReadCodec::getOneRttReadCipher() const {
+const Aead* QuicReadCodec::getOneRttReadCipher() const {
   return oneRttReadCipher_.get();
 }
 
-const fizz::Aead* QuicReadCodec::getZeroRttReadCipher() const {
+const Aead* QuicReadCodec::getZeroRttReadCipher() const {
   return zeroRttReadCipher_.get();
 }
 
-const fizz::Aead* QuicReadCodec::getHandshakeReadCipher() const {
+const Aead* QuicReadCodec::getHandshakeReadCipher() const {
   return handshakeReadCipher_.get();
 }
 
@@ -352,17 +352,17 @@ QuicReadCodec::getStatelessResetToken() const {
 }
 
 void QuicReadCodec::setInitialReadCipher(
-    std::unique_ptr<fizz::Aead> initialReadCipher) {
+    std::unique_ptr<Aead> initialReadCipher) {
   initialReadCipher_ = std::move(initialReadCipher);
 }
 
 void QuicReadCodec::setOneRttReadCipher(
-    std::unique_ptr<fizz::Aead> oneRttReadCipher) {
+    std::unique_ptr<Aead> oneRttReadCipher) {
   oneRttReadCipher_ = std::move(oneRttReadCipher);
 }
 
 void QuicReadCodec::setZeroRttReadCipher(
-    std::unique_ptr<fizz::Aead> zeroRttReadCipher) {
+    std::unique_ptr<Aead> zeroRttReadCipher) {
   if (nodeType_ == QuicNodeType::Client) {
     throw QuicTransportException(
         "Invalid cipher", TransportErrorCode::INTERNAL_ERROR);
@@ -371,7 +371,7 @@ void QuicReadCodec::setZeroRttReadCipher(
 }
 
 void QuicReadCodec::setHandshakeReadCipher(
-    std::unique_ptr<fizz::Aead> handshakeReadCipher) {
+    std::unique_ptr<Aead> handshakeReadCipher) {
   handshakeReadCipher_ = std::move(handshakeReadCipher);
 }
 
@@ -412,7 +412,7 @@ void QuicReadCodec::setStatelessResetToken(
   statelessResetToken_ = std::move(statelessResetToken);
 }
 
-const fizz::Aead* QuicReadCodec::getInitialCipher() const {
+const Aead* QuicReadCodec::getInitialCipher() const {
   return initialReadCipher_.get();
 }
 

--- a/quic/codec/QuicReadCodec.h
+++ b/quic/codec/QuicReadCodec.h
@@ -56,11 +56,11 @@ class QuicReadCodec {
       folly::IOBufQueue& queue,
       const AckStates& ackStates);
 
-  const fizz::Aead* getOneRttReadCipher() const;
-  const fizz::Aead* getZeroRttReadCipher() const;
-  const fizz::Aead* getHandshakeReadCipher() const;
+  const Aead* getOneRttReadCipher() const;
+  const Aead* getZeroRttReadCipher() const;
+  const Aead* getHandshakeReadCipher() const;
 
-  const fizz::Aead* getInitialCipher() const;
+  const Aead* getInitialCipher() const;
 
   const PacketNumberCipher* getInitialHeaderCipher() const;
   const PacketNumberCipher* getOneRttHeaderCipher() const;
@@ -69,10 +69,10 @@ class QuicReadCodec {
 
   const folly::Optional<StatelessResetToken>& getStatelessResetToken() const;
 
-  void setInitialReadCipher(std::unique_ptr<fizz::Aead> initialReadCipher);
-  void setOneRttReadCipher(std::unique_ptr<fizz::Aead> oneRttReadCipher);
-  void setZeroRttReadCipher(std::unique_ptr<fizz::Aead> zeroRttReadCipher);
-  void setHandshakeReadCipher(std::unique_ptr<fizz::Aead> handshakeReadCipher);
+  void setInitialReadCipher(std::unique_ptr<Aead> initialReadCipher);
+  void setOneRttReadCipher(std::unique_ptr<Aead> oneRttReadCipher);
+  void setZeroRttReadCipher(std::unique_ptr<Aead> zeroRttReadCipher);
+  void setHandshakeReadCipher(std::unique_ptr<Aead> handshakeReadCipher);
 
   void setInitialHeaderCipher(
       std::unique_ptr<PacketNumberCipher> initialHeaderCipher);
@@ -110,11 +110,11 @@ class QuicReadCodec {
   folly::Optional<ConnectionId> serverConnectionId_;
 
   // Cipher used to decrypt handshake packets.
-  std::unique_ptr<fizz::Aead> initialReadCipher_;
+  std::unique_ptr<Aead> initialReadCipher_;
 
-  std::unique_ptr<fizz::Aead> oneRttReadCipher_;
-  std::unique_ptr<fizz::Aead> zeroRttReadCipher_;
-  std::unique_ptr<fizz::Aead> handshakeReadCipher_;
+  std::unique_ptr<Aead> oneRttReadCipher_;
+  std::unique_ptr<Aead> zeroRttReadCipher_;
+  std::unique_ptr<Aead> handshakeReadCipher_;
 
   std::unique_ptr<PacketNumberCipher> initialHeaderCipher_;
   std::unique_ptr<PacketNumberCipher> oneRttHeaderCipher_;

--- a/quic/codec/test/QuicPacketBuilderTest.cpp
+++ b/quic/codec/test/QuicPacketBuilderTest.cpp
@@ -31,7 +31,7 @@ std::vector<QuicVersion> versionList(
 
 Buf packetToBuf(
     RegularQuicPacketBuilder::Packet& packet,
-    fizz::Aead* aead = nullptr) {
+    Aead* aead = nullptr) {
   auto buf = folly::IOBuf::create(0);
   // This doesnt matter.
   PacketNum num = 10;
@@ -62,8 +62,8 @@ constexpr size_t kVersionNegotiationHeaderSize =
 std::unique_ptr<QuicReadCodec> makeCodec(
     ConnectionId clientConnId,
     QuicNodeType nodeType,
-    std::unique_ptr<fizz::Aead> zeroRttCipher = nullptr,
-    std::unique_ptr<fizz::Aead> oneRttCipher = nullptr) {
+    std::unique_ptr<Aead> zeroRttCipher = nullptr,
+    std::unique_ptr<Aead> oneRttCipher = nullptr) {
   QuicFizzFactory fizzFactory;
   auto codec = std::make_unique<QuicReadCodec>(nodeType);
   if (nodeType != QuicNodeType::Client) {

--- a/quic/codec/test/QuicReadCodecTest.cpp
+++ b/quic/codec/test/QuicReadCodecTest.cpp
@@ -40,8 +40,8 @@ std::unique_ptr<QuicReadCodec> makeUnencryptedCodec() {
 
 std::unique_ptr<QuicReadCodec> makeEncryptedCodec(
     ConnectionId clientConnId,
-    std::unique_ptr<fizz::Aead> oneRttAead,
-    std::unique_ptr<fizz::Aead> zeroRttAead = nullptr,
+    std::unique_ptr<Aead> oneRttAead,
+    std::unique_ptr<Aead> zeroRttAead = nullptr,
     std::unique_ptr<StatelessResetToken> sourceToken = nullptr) {
   QuicFizzFactory fizzFactory;
   auto codec = std::make_unique<QuicReadCodec>(QuicNodeType::Server);

--- a/quic/common/test/TestUtils.cpp
+++ b/quic/common/test/TestUtils.cpp
@@ -106,7 +106,7 @@ RegularQuicPacketBuilder::Packet createAckPacket(
     PacketNum pn,
     IntervalSet<PacketNum>& acks,
     PacketNumberSpace pnSpace,
-    const fizz::Aead* aead) {
+    const Aead* aead) {
   // This function sends ACK to dstConn
   auto srcConnId =
       (dstConn.nodeType == QuicNodeType::Client ? *dstConn.serverConnectionId
@@ -360,7 +360,7 @@ RegularQuicPacketBuilder::Packet createInitialCryptoPacket(
     PacketNum packetNum,
     QuicVersion version,
     folly::IOBuf& data,
-    const fizz::Aead& aead,
+    const Aead& aead,
     PacketNum largestAcked,
     uint64_t offset) {
   LongHeader header(
@@ -379,7 +379,7 @@ RegularQuicPacketBuilder::Packet createCryptoPacket(
     QuicVersion version,
     ProtectionType protectionType,
     folly::IOBuf& data,
-    const fizz::Aead& aead,
+    const Aead& aead,
     PacketNum largestAcked,
     uint64_t offset,
     uint64_t packetSizeLimit) {
@@ -431,7 +431,7 @@ Buf packetToBuf(const RegularQuicPacketBuilder::Packet& packet) {
 
 Buf packetToBufCleartext(
     const RegularQuicPacketBuilder::Packet& packet,
-    const fizz::Aead& cleartextCipher,
+    const Aead& cleartextCipher,
     const PacketNumberCipher& headerCipher,
     PacketNum packetNum) {
   VLOG(10) << __func__ << " packet header: "

--- a/quic/common/test/TestUtils.h
+++ b/quic/common/test/TestUtils.h
@@ -58,7 +58,7 @@ RegularQuicPacketBuilder::Packet createAckPacket(
     PacketNum pn,
     IntervalSet<PacketNum>& acks,
     PacketNumberSpace pnSpace,
-    const fizz::Aead* aead = nullptr);
+    const Aead* aead = nullptr);
 
 PacketNum rstStreamAndSendPacket(
     QuicServerConnectionState& conn,
@@ -90,7 +90,7 @@ RegularQuicPacketBuilder::Packet createInitialCryptoPacket(
     PacketNum packetNum,
     QuicVersion version,
     folly::IOBuf& data,
-    const fizz::Aead& aead,
+    const Aead& aead,
     PacketNum largestAcked,
     uint64_t offset = 0);
 
@@ -101,7 +101,7 @@ RegularQuicPacketBuilder::Packet createCryptoPacket(
     QuicVersion version,
     ProtectionType protectionType,
     folly::IOBuf& data,
-    const fizz::Aead& aead,
+    const Aead& aead,
     PacketNum largestAcked,
     uint64_t offset = 0,
     uint64_t packetSizeLimit = kDefaultUDPSendPacketLen);
@@ -110,7 +110,7 @@ Buf packetToBuf(const RegularQuicPacketBuilder::Packet& packet);
 
 Buf packetToBufCleartext(
     const RegularQuicPacketBuilder::Packet& packet,
-    const fizz::Aead& cleartextCipher,
+    const Aead& cleartextCipher,
     const PacketNumberCipher& headerCipher,
     PacketNum packetNum);
 

--- a/quic/handshake/FizzBridge.h
+++ b/quic/handshake/FizzBridge.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#pragma once
+
+#include <fizz/crypto/aead/Aead.h>
+
+namespace quic {
+using Aead = fizz::Aead;
+}

--- a/quic/handshake/HandshakeLayer.cpp
+++ b/quic/handshake/HandshakeLayer.cpp
@@ -45,7 +45,7 @@ Buf makeClientInitialTrafficSecret(
       factory, kClientInitialLabel, clientDestinationConnId);
 }
 
-std::unique_ptr<fizz::Aead> makeInitialAead(
+std::unique_ptr<Aead> makeInitialAead(
     fizz::Factory* factory,
     folly::StringPiece label,
     const ConnectionId& clientDestinationConnId) {
@@ -70,13 +70,13 @@ std::unique_ptr<fizz::Aead> makeInitialAead(
   return aead;
 }
 
-std::unique_ptr<fizz::Aead> getClientInitialCipher(
+std::unique_ptr<Aead> getClientInitialCipher(
     fizz::Factory* factory,
     const ConnectionId& clientDestinationConnId) {
   return makeInitialAead(factory, kClientInitialLabel, clientDestinationConnId);
 }
 
-std::unique_ptr<fizz::Aead> getServerInitialCipher(
+std::unique_ptr<Aead> getServerInitialCipher(
     fizz::Factory* factory,
     const ConnectionId& clientDestinationConnId) {
   return makeInitialAead(factory, kServerInitialLabel, clientDestinationConnId);

--- a/quic/handshake/HandshakeLayer.h
+++ b/quic/handshake/HandshakeLayer.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <fizz/crypto/aead/Aead.h>
 #include <fizz/protocol/Exporter.h>
 #include <fizz/protocol/Factory.h>
 #include <fizz/protocol/Types.h>
@@ -18,6 +17,7 @@
 #include <quic/QuicConstants.h>
 #include <quic/codec/PacketNumberCipher.h>
 #include <quic/codec/Types.h>
+#include <quic/handshake/FizzBridge.h>
 #include <quic/handshake/QuicFizzFactory.h>
 
 namespace fizz {
@@ -45,16 +45,16 @@ constexpr folly::StringPiece kQuicDraft17Salt =
 constexpr folly::StringPiece kClientInitialLabel = "client in";
 constexpr folly::StringPiece kServerInitialLabel = "server in";
 
-std::unique_ptr<fizz::Aead> makeInitialAead(
+std::unique_ptr<Aead> makeInitialAead(
     fizz::Factory* factory,
     folly::StringPiece label,
     const ConnectionId& clientDestinationConnId);
 
-std::unique_ptr<fizz::Aead> getClientInitialCipher(
+std::unique_ptr<Aead> getClientInitialCipher(
     fizz::Factory* factory,
     const ConnectionId& clientDestinationConnId);
 
-std::unique_ptr<fizz::Aead> getServerInitialCipher(
+std::unique_ptr<Aead> getServerInitialCipher(
     fizz::Factory* factory,
     const ConnectionId& clientDestinationConnId);
 

--- a/quic/handshake/test/HandshakeLayerTest.cpp
+++ b/quic/handshake/test/HandshakeLayerTest.cpp
@@ -9,7 +9,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <fizz/crypto/aead/test/Mocks.h>
 #include <quic/codec/QuicConnectionId.h>
 #include <quic/common/test/TestUtils.h>
 #include <quic/handshake/HandshakeLayer.h>
@@ -36,7 +35,7 @@ class QuicTestFizzFactory : public QuicFizzFactory {
     return std::move(packetNumberCipher_);
   }
 
-  void setMockAead(std::unique_ptr<fizz::test::MockAead> aead) {
+  void setMockAead(std::unique_ptr<fizz::Aead> aead) {
     aead_ = std::move(aead);
   }
 

--- a/quic/loss/test/QuicLossFunctionsTest.cpp
+++ b/quic/loss/test/QuicLossFunctionsTest.cpp
@@ -112,7 +112,7 @@ class QuicLossFunctionsTest : public TestWithParam<PacketNumberSpace> {
   }
 
   EventBase evb;
-  std::unique_ptr<fizz::Aead> aead;
+  std::unique_ptr<Aead> aead;
   std::unique_ptr<PacketNumberCipher> headerCipher;
   MockLossTimeout timeout;
   std::unique_ptr<MockQuicStats> transportInfoCb_;

--- a/quic/server/handshake/ServerHandshake.cpp
+++ b/quic/server/handshake/ServerHandshake.cpp
@@ -88,35 +88,35 @@ void ServerHandshake::writeNewSessionTicket(const AppToken& appToken) {
   }
 }
 
-std::unique_ptr<fizz::Aead> ServerHandshake::getHandshakeWriteCipher() {
+std::unique_ptr<Aead> ServerHandshake::getHandshakeWriteCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
   return std::move(handshakeWriteCipher_);
 }
 
-std::unique_ptr<fizz::Aead> ServerHandshake::getHandshakeReadCipher() {
+std::unique_ptr<Aead> ServerHandshake::getHandshakeReadCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
   return std::move(handshakeReadCipher_);
 }
 
-std::unique_ptr<fizz::Aead> ServerHandshake::getOneRttWriteCipher() {
+std::unique_ptr<Aead> ServerHandshake::getOneRttWriteCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
   return std::move(oneRttWriteCipher_);
 }
 
-std::unique_ptr<fizz::Aead> ServerHandshake::getOneRttReadCipher() {
+std::unique_ptr<Aead> ServerHandshake::getOneRttReadCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
   return std::move(oneRttReadCipher_);
 }
 
-std::unique_ptr<fizz::Aead> ServerHandshake::getZeroRttReadCipher() {
+std::unique_ptr<Aead> ServerHandshake::getZeroRttReadCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }

--- a/quic/server/handshake/ServerHandshake.h
+++ b/quic/server/handshake/ServerHandshake.h
@@ -105,31 +105,31 @@ class ServerHandshake : public Handshake {
    * An edge triggered API to get the handshakeWriteCipher. Once you receive the
    * write cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getHandshakeWriteCipher();
+  std::unique_ptr<Aead> getHandshakeWriteCipher();
 
   /**
    * An edge triggered API to get the handshakeReadCipher. Once you receive the
    * write cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getHandshakeReadCipher();
+  std::unique_ptr<Aead> getHandshakeReadCipher();
 
   /**
    * An edge triggered API to get the oneRttWriteCipher. Once you receive the
    * write cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getOneRttWriteCipher();
+  std::unique_ptr<Aead> getOneRttWriteCipher();
 
   /**
    * An edge triggered API to get the oneRttReadCipher. Once you receive the
    * read cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getOneRttReadCipher();
+  std::unique_ptr<Aead> getOneRttReadCipher();
 
   /**
    * An edge triggered API to get the zeroRttReadCipher. Once you receive the
    * zero rtt read cipher subsequent calls will return null.
    */
-  std::unique_ptr<fizz::Aead> getZeroRttReadCipher();
+  std::unique_ptr<Aead> getZeroRttReadCipher();
 
   /**
    * An edge triggered API to get the one rtt read header cpher. Once you

--- a/quic/server/handshake/test/ServerHandshakeTest.cpp
+++ b/quic/server/handshake/test/ServerHandshakeTest.cpp
@@ -324,11 +324,11 @@ class ServerHandshakeTest : public Test {
   std::vector<fizz::WriteToSocket> clientWrites;
   MockServerHandshakeCallback serverCallback;
 
-  std::unique_ptr<fizz::Aead> oneRttWriteCipher;
-  std::unique_ptr<fizz::Aead> oneRttReadCipher;
-  std::unique_ptr<fizz::Aead> zeroRttReadCipher;
-  std::unique_ptr<fizz::Aead> handshakeWriteCipher;
-  std::unique_ptr<fizz::Aead> handshakeReadCipher;
+  std::unique_ptr<Aead> oneRttWriteCipher;
+  std::unique_ptr<Aead> oneRttReadCipher;
+  std::unique_ptr<Aead> zeroRttReadCipher;
+  std::unique_ptr<Aead> handshakeWriteCipher;
+  std::unique_ptr<Aead> handshakeReadCipher;
 
   std::exception_ptr ex;
   std::string hostname;

--- a/quic/server/test/QuicServerTransportTest.cpp
+++ b/quic/server/test/QuicServerTransportTest.cpp
@@ -314,7 +314,7 @@ class QuicServerTransportTest : public Test {
     fakeHandshake = new FakeServerHandshake(server->getNonConstConn());
   }
 
-  std::unique_ptr<fizz::Aead> getInitialCipher() {
+  std::unique_ptr<Aead> getInitialCipher() {
     QuicFizzFactory fizzFactory;
     return getClientInitialCipher(
         &fizzFactory, *initialDestinationConnectionId);
@@ -2889,7 +2889,7 @@ TEST_F(QuicUnencryptedServerTransportTest, TestGarbageData) {
 Buf getHandshakePacketWithFrame(
     QuicWriteFrame frame,
     ConnectionId connId,
-    fizz::Aead& clientWriteCipher,
+    Aead& clientWriteCipher,
     PacketNumberCipher& headerCipher) {
   PacketNum clientPacketNum = folly::Random::rand32();
   LongHeader header(

--- a/quic/state/StateData.h
+++ b/quic/state/StateData.h
@@ -415,17 +415,17 @@ struct QuicConnectionStateBase {
   std::unique_ptr<PacketNumberCipher> oneRttWriteHeaderCipher;
 
   // Write cipher for 1-RTT data
-  std::unique_ptr<fizz::Aead> oneRttWriteCipher;
+  std::unique_ptr<Aead> oneRttWriteCipher;
 
   // Write cipher for packets with initial keys.
-  std::unique_ptr<fizz::Aead> initialWriteCipher;
+  std::unique_ptr<Aead> initialWriteCipher;
 
   // Write cipher for packets with handshake keys.
-  std::unique_ptr<fizz::Aead> handshakeWriteCipher;
+  std::unique_ptr<Aead> handshakeWriteCipher;
 
   // Write cipher for 0-RTT data
   // TODO: move this back into the client state
-  std::unique_ptr<fizz::Aead> zeroRttWriteCipher;
+  std::unique_ptr<Aead> zeroRttWriteCipher;
 
   // Time at which the connection started.
   TimePoint connectionTime;


### PR DESCRIPTION
This introduce quic::Aead as a simple typedef to fizz::Aead and update the codebase to use quic::Aead . This should not impact the functionality of the code in any way.

This is a first step toward introducing an interface that is specific for mvfst so that mvfst can swap fizz for something else.