### PR TITLE
Update README with client and server commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ You might need to run the script as root to install to certain directories.
 By default the build script `build_helper.sh` enables the building of test target (i.e. runs with `-DBUILD_TEST=ON` option). Since some of tests in `mvfst` require some test artifacts of Fizz, it is necessary to supply the path of the Fizz src directory (via option `DFIZZ_PROJECT`) to correctly build all test targets in `mvfst`.
 
 ## Run a sample client and server
-Building the test targets of `mvfst` (or via `build_helper.sh`) should automatically build the sample client and server binaries as well. You can then spin a simple echo server by running:
+Building the test targets of `mvfst` (or via `build_helper.sh`) should automatically build the sample client and server binaries as well. The server will automatically bind to `::1` by default, but you can then spin a simple echo server by running:
 ```
-./quic/samples/echo -mode=server -host=<ip> -port=<port>
+./quic/samples/echo -mode=server -port=<port>
 ```
 and to run a client:
 ```
-./quic/samples/echo -mode=client  -host=<ip> -port=<port>
+./quic/samples/echo -mode=client -host=::1 -port=<port>
 ```
 For more options, see
 ```

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ You might need to run the script as root to install to certain directories.
 By default the build script `build_helper.sh` enables the building of test target (i.e. runs with `-DBUILD_TEST=ON` option). Since some of tests in `mvfst` require some test artifacts of Fizz, it is necessary to supply the path of the Fizz src directory (via option `DFIZZ_PROJECT`) to correctly build all test targets in `mvfst`.
 
 ## Run a sample client and server
-Building the test targets of `mvfst` (or via `build_helper.sh`) should automatically build the sample client and server binaries as well. The server will automatically bind to `::1` by default, but you can then spin a simple echo server by running:
+Building the test targets of `mvfst` (or via `build_helper.sh`) should automatically build the sample client and server binaries as well. The server will automatically bind to `::1` by default if no host is used, but you can then spin a simple echo server by running:
 ```
-./quic/samples/echo -mode=server -port=<port>
+./quic/samples/echo -mode=server -host=<host> -port=<port>
 ```
 and to run a client:
 ```
-./quic/samples/echo -mode=client -host=::1 -port=<port>
+./quic/samples/echo -mode=client -host=<host> -port=<port>
 ```
 For more options, see
 ```

--- a/quic/samples/echo/EchoServer.h
+++ b/quic/samples/echo/EchoServer.h
@@ -59,8 +59,11 @@ class EchoServerTransportFactory : public quic::QuicServerTransportFactory {
 
 class EchoServer {
  public:
-  explicit EchoServer(uint16_t port, bool prEnabled = false)
-      : port_(port),
+  explicit EchoServer(const std::string& host = "::1", 
+                      uint16_t port = 6666, 
+                      bool prEnabled = false)
+      : host_(host),
+        port_(port),
         prEnabled_(prEnabled),
         server_(QuicServer::createQuicServer()) {
     server_->setQuicServerTransportFactory(
@@ -74,14 +77,16 @@ class EchoServer {
   }
 
   void start() {
-    folly::SocketAddress addr1;
-    addr1.setFromLocalPort(port_);
+    // Create a SocketAddress and the default or passed in host. 
+    folly::SocketAddress addr1(host_.c_str(), port_);
+    addr1.setFromHostPort(host_, port_);
     server_->start(addr1, 0);
     LOG(INFO) << "Echo server started at: " << addr1.describe();
     eventbase_.loopForever();
   }
 
  private:
+  std::string host_;
   uint16_t port_;
   bool prEnabled_;
   folly::EventBase eventbase_;

--- a/quic/samples/echo/main.cpp
+++ b/quic/samples/echo/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]) {
   fizz::CryptoUtils::init();
 
   if (FLAGS_mode == "server") {
-    EchoServer server(FLAGS_port, FLAGS_pr);
+    EchoServer server(FLAGS_host, FLAGS_port, FLAGS_pr);
     server.start();
   } else if (FLAGS_mode == "client") {
     if (FLAGS_host.empty() || FLAGS_port == 0) {


### PR DESCRIPTION
Update README echo server sample commands. 
The IPv6 localhost address `::1` was added on the client and the `-host` argument was removed on the server because this is the default address by default.