### PR TITLE
Decouple fizz:test::MockAead from MockAead. Use the former for code that actually needs fizz.

### DIFF
--- a/quic/api/test/QuicTransportFunctionsTest.cpp
+++ b/quic/api/test/QuicTransportFunctionsTest.cpp
@@ -1010,7 +1010,7 @@ TEST_F(QuicTransportFunctionsTest, WriteProbingOldData) {
   auto socket = std::make_unique<folly::test::MockAsyncUDPSocket>(&evb);
   auto rawSocket = socket.get();
   EXPECT_CALL(*rawSocket, write(_, _)).WillRepeatedly(Return(100));
-  auto capturingAead = std::make_unique<fizz::test::MockAead>();
+  auto capturingAead = std::make_unique<MockAead>();
   auto stream = conn->streamManager->createNextBidirectionalStream().value();
   auto buf = folly::IOBuf::copyBuffer("Where you wanna go");
   writeDataToQuicStream(*stream, buf->clone(), true);

--- a/quic/api/test/QuicTransportTest.cpp
+++ b/quic/api/test/QuicTransportTest.cpp
@@ -9,7 +9,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <fizz/crypto/aead/test/Mocks.h>
 #include <folly/Random.h>
 #include <folly/io/Cursor.h>
 #include <folly/io/IOBufQueue.h>
@@ -19,6 +18,7 @@
 #include <quic/api/test/Mocks.h>
 #include <quic/common/Timers.h>
 #include <quic/common/test/TestUtils.h>
+#include <quic/handshake/test/Mocks.h>
 #include <quic/server/state/ServerStateMachine.h>
 #include <quic/state/QuicStreamFunctions.h>
 #include <quic/state/test/Mocks.h>
@@ -182,7 +182,7 @@ class QuicTransportTest : public Test {
         new TestQuicTransport(&evb_, std::move(sock), connCallback_));
     // Set the write handshake state to tell the client that the handshake has
     // a cipher.
-    auto aead = std::make_unique<fizz::test::MockAead>();
+    auto aead = std::make_unique<MockAead>();
     aead_ = aead.get();
     EXPECT_CALL(*aead_, _encrypt(_, _, _))
         .WillRepeatedly(
@@ -221,7 +221,7 @@ class QuicTransportTest : public Test {
   MockAsyncUDPSocket* socket_;
   MockConnectionCallback connCallback_;
   MockWriteCallback writeCallback_;
-  fizz::test::MockAead* aead_;
+  MockAead* aead_;
   std::unique_ptr<PacketNumberCipher> headerCipher_;
   std::shared_ptr<TestQuicTransport> transport_;
 };

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -14,7 +14,6 @@
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
 
-#include <fizz/crypto/aead/test/Mocks.h>
 #include <folly/futures/Future.h>
 #include <folly/io/Cursor.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
@@ -23,6 +22,7 @@
 #include <quic/codec/DefaultConnectionIdAlgo.h>
 #include <quic/common/test/TestUtils.h>
 #include <quic/congestion_control/CongestionControllerFactory.h>
+#include <quic/handshake/test/Mocks.h>
 #include <quic/handshake/TransportParameters.h>
 #include <quic/happyeyeballs/QuicHappyEyeballsFunctions.h>
 #include <quic/samples/echo/EchoHandler.h>
@@ -1006,10 +1006,10 @@ class QuicClientTransportTest : public Test {
   }
 
   virtual void setFakeHandshakeCiphers() {
-    auto readAead = test::createNoOpAead();
-    auto writeAead = test::createNoOpAead();
-    auto handshakeReadAead = test::createNoOpAead();
-    auto handshakeWriteAead = test::createNoOpAead();
+    auto readAead = test::createNoOpFizzAead();
+    auto writeAead = test::createNoOpFizzAead();
+    auto handshakeReadAead = test::createNoOpFizzAead();
+    auto handshakeWriteAead = test::createNoOpFizzAead();
     mockClientHandshake->setHandshakeReadCipher(std::move(handshakeReadAead));
     mockClientHandshake->setHandshakeWriteCipher(std::move(handshakeWriteAead));
     mockClientHandshake->setOneRttReadCipher(std::move(readAead));
@@ -3989,11 +3989,11 @@ class QuicZeroRttClientTest : public QuicClientTransportAfterStartTest {
   ~QuicZeroRttClientTest() override = default;
 
   void setFakeHandshakeCiphers() override {
-    auto readAead = test::createNoOpAead();
-    auto writeAead = test::createNoOpAead();
-    auto zeroAead = test::createNoOpAead();
-    auto handshakeReadAead = test::createNoOpAead();
-    auto handshakeWriteAead = test::createNoOpAead();
+    auto readAead = test::createNoOpFizzAead();
+    auto writeAead = test::createNoOpFizzAead();
+    auto zeroAead = test::createNoOpFizzAead();
+    auto handshakeReadAead = test::createNoOpFizzAead();
+    auto handshakeWriteAead = test::createNoOpFizzAead();
     mockClientHandshake->setOneRttReadCipher(std::move(readAead));
     mockClientHandshake->setOneRttWriteCipher(std::move(writeAead));
     mockClientHandshake->setZeroRttWriteCipher(std::move(zeroAead));

--- a/quic/codec/test/QuicReadCodecTest.cpp
+++ b/quic/codec/test/QuicReadCodecTest.cpp
@@ -192,7 +192,7 @@ TEST_F(QuicReadCodecTest, StreamWithShortHeaderOnlyHeader) {
       kDefaultUDPSendPacketLen, std::move(header), 0 /* largestAcked */);
   auto packetBuf = packetToBuf(std::move(builder).buildPacket());
 
-  auto aead = std::make_unique<fizz::test::MockAead>();
+  auto aead = std::make_unique<MockAead>();
   // The size is not large enough.
   EXPECT_CALL(*aead, _tryDecrypt(_, _, _)).Times(0);
   AckStates ackStates;
@@ -207,7 +207,7 @@ TEST_F(QuicReadCodecTest, PacketDecryptFail) {
   PacketNum packetNum = 12321;
   StreamId streamId = 2;
 
-  auto aead = std::make_unique<fizz::test::MockAead>();
+  auto aead = std::make_unique<MockAead>();
   EXPECT_CALL(*aead, _tryDecrypt(_, _, _))
       .WillOnce(Invoke([](auto&, const auto, auto) { return folly::none; }));
   auto data = folly::IOBuf::copyBuffer("hello");
@@ -321,7 +321,7 @@ TEST_F(QuicReadCodecTest, KeyPhaseOnePacket) {
 
 TEST_F(QuicReadCodecTest, FailToDecryptLeadsToReset) {
   auto connId = getTestConnectionId();
-  auto aead = std::make_unique<fizz::test::MockAead>();
+  auto aead = std::make_unique<MockAead>();
   auto rawAead = aead.get();
 
   StatelessResetToken tok(
@@ -355,7 +355,7 @@ TEST_F(QuicReadCodecTest, FailToDecryptLeadsToReset) {
 
 TEST_F(QuicReadCodecTest, ShortPacketAutoPaddedIsReset) {
   auto connId = getTestConnectionId();
-  auto aead = std::make_unique<fizz::test::MockAead>();
+  auto aead = std::make_unique<MockAead>();
   auto rawAead = aead.get();
   StatelessResetToken tok(
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
@@ -389,7 +389,7 @@ TEST_F(QuicReadCodecTest, ShortPacketAutoPaddedIsReset) {
 
 TEST_F(QuicReadCodecTest, FailToDecryptLongHeaderNoReset) {
   auto connId = getTestConnectionId();
-  auto aead = std::make_unique<fizz::test::MockAead>();
+  auto aead = std::make_unique<MockAead>();
   auto rawAead = aead.get();
 
   StatelessResetToken tok(
@@ -422,7 +422,7 @@ TEST_F(QuicReadCodecTest, FailToDecryptLongHeaderNoReset) {
 
 TEST_F(QuicReadCodecTest, FailToDecryptNoTokenNoReset) {
   auto connId = getTestConnectionId();
-  auto aead = std::make_unique<fizz::test::MockAead>();
+  auto aead = std::make_unique<MockAead>();
   auto rawAead = aead.get();
 
   auto codec = makeEncryptedCodec(connId, std::move(aead), nullptr);

--- a/quic/common/test/TestUtils.cpp
+++ b/quic/common/test/TestUtils.cpp
@@ -276,7 +276,7 @@ void setupCtxWithTestCert(fizz::server::FizzServerContext& ctx) {
   ctx.setCertManager(std::move(certManager));
 }
 
-std::unique_ptr<fizz::test::MockAead> createNoOpAead() {
+std::unique_ptr<MockAead> createNoOpAead() {
   // Fake that the handshake has already occured
   auto aead = std::make_unique<NiceMock<fizz::test::MockAead>>();
   ON_CALL(*aead, _encrypt(_, _, _))
@@ -298,6 +298,10 @@ std::unique_ptr<fizz::test::MockAead> createNoOpAead() {
   ON_CALL(*aead, ivLength()).WillByDefault(Return(16));
   ON_CALL(*aead, getCipherOverhead()).WillByDefault(Return(0));
   return aead;
+}
+
+std::unique_ptr<fizz::test::MockAead> createNoOpFizzAead() {
+  return createNoOpAead();
 }
 
 std::unique_ptr<PacketNumberCipher> createNoOpHeaderCipher() {

--- a/quic/common/test/TestUtils.h
+++ b/quic/common/test/TestUtils.h
@@ -12,6 +12,7 @@
 #include <quic/codec/QuicPacketBuilder.h>
 #include <quic/codec/Types.h>
 #include <quic/common/test/QuicCodecUtils.h>
+#include <quic/handshake/test/Mocks.h>
 #include <quic/server/state/ServerStateMachine.h>
 #include <quic/state/AckStates.h>
 #include <quic/state/StateData.h>
@@ -135,7 +136,8 @@ QuicCachedPsk setupZeroRttOnClientCtx(
     std::string hostname,
     QuicVersion version);
 
-std::unique_ptr<fizz::test::MockAead> createNoOpAead();
+std::unique_ptr<MockAead> createNoOpAead();
+std::unique_ptr<fizz::test::MockAead> createNoOpFizzAead();
 
 std::unique_ptr<PacketNumberCipher> createNoOpHeaderCipher();
 

--- a/quic/handshake/test/Mocks.h
+++ b/quic/handshake/test/Mocks.h
@@ -6,6 +6,9 @@
  *
  */
 
+#pragma once
+
+#include <fizz/crypto/aead/test/Mocks.h>
 #include <gmock/gmock.h>
 #include <quic/codec/PacketNumberCipher.h>
 
@@ -20,5 +23,7 @@ class MockPacketNumberCipher : public PacketNumberCipher {
   MOCK_CONST_METHOD1(mask, HeaderProtectionMask(folly::ByteRange));
   MOCK_CONST_METHOD0(keyLength, size_t());
 };
+
+using MockAead = fizz::test::MockAead;
 } // namespace test
 } // namespace quic

--- a/quic/server/test/QuicServerTransportTest.cpp
+++ b/quic/server/test/QuicServerTransportTest.cpp
@@ -133,9 +133,9 @@ class FakeServerHandshake : public ServerHandshake {
   }
 
   void setEarlyKeys() {
-    oneRttWriteCipher_ = createNoOpAead();
+    oneRttWriteCipher_ = createNoOpFizzAead();
     oneRttWriteHeaderCipher_ = createNoOpHeaderCipher();
-    zeroRttReadCipher_ = createNoOpAead();
+    zeroRttReadCipher_ = createNoOpFizzAead();
     zeroRttReadHeaderCipher_ = createNoOpHeaderCipher();
   }
 
@@ -143,17 +143,17 @@ class FakeServerHandshake : public ServerHandshake {
     // Mimic ServerHandshake behavior.
     // oneRttWriteCipher would already be set during ReportEarlyHandshakeSuccess
     if (!allowZeroRttKeys_) {
-      oneRttWriteCipher_ = createNoOpAead();
+      oneRttWriteCipher_ = createNoOpFizzAead();
       oneRttWriteHeaderCipher_ = createNoOpHeaderCipher();
     }
-    oneRttReadCipher_ = createNoOpAead();
+    oneRttReadCipher_ = createNoOpFizzAead();
     oneRttReadHeaderCipher_ = createNoOpHeaderCipher();
   }
 
   void setHandshakeKeys() {
-    handshakeWriteCipher_ = createNoOpAead();
+    handshakeWriteCipher_ = createNoOpFizzAead();
     handshakeWriteHeaderCipher_ = createNoOpHeaderCipher();
-    handshakeReadCipher_ = createNoOpAead();
+    handshakeReadCipher_ = createNoOpFizzAead();
     handshakeReadHeaderCipher_ = createNoOpHeaderCipher();
   }
 


### PR DESCRIPTION
This is based on top of #12 .

It logically split MockAead and fizz::MockAead in preparation for separation of the two.