### PR TITLE
Decouple fizz::Aead and quic::Aead . This makes a large chunk of the codebase fizz agnostic.

### DIFF
--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -9,6 +9,7 @@
 #include <quic/client/handshake/ClientHandshake.h>
 
 #include <fizz/protocol/Protocol.h>
+#include <quic/handshake/FizzBridge.h>
 #include <quic/state/QuicStreamFunctions.h>
 
 namespace quic {
@@ -94,35 +95,35 @@ std::unique_ptr<Aead> ClientHandshake::getOneRttWriteCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return std::move(oneRttWriteCipher_);
+  return FizzAead::wrap(std::move(oneRttWriteCipher_));
 }
 
 std::unique_ptr<Aead> ClientHandshake::getOneRttReadCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return std::move(oneRttReadCipher_);
+  return FizzAead::wrap(std::move(oneRttReadCipher_));
 }
 
 std::unique_ptr<Aead> ClientHandshake::getZeroRttWriteCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return std::move(zeroRttWriteCipher_);
+  return FizzAead::wrap(std::move(zeroRttWriteCipher_));
 }
 
 std::unique_ptr<Aead> ClientHandshake::getHandshakeReadCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return std::move(handshakeReadCipher_);
+  return FizzAead::wrap(std::move(handshakeReadCipher_));
 }
 
 std::unique_ptr<Aead> ClientHandshake::getHandshakeWriteCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return std::move(handshakeWriteCipher_);
+  return FizzAead::wrap(std::move(handshakeWriteCipher_));
 }
 
 std::unique_ptr<PacketNumberCipher>

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -23,6 +23,7 @@
 #include <quic/codec/DefaultConnectionIdAlgo.h>
 #include <quic/common/test/TestUtils.h>
 #include <quic/congestion_control/CongestionControllerFactory.h>
+#include <quic/handshake/FizzBridge.h>
 #include <quic/handshake/TransportParameters.h>
 #include <quic/handshake/test/Mocks.h>
 #include <quic/happyeyeballs/QuicHappyEyeballsFunctions.h>
@@ -3303,9 +3304,17 @@ TEST_F(QuicClientTransportAfterStartTest, SwitchEvbWhileAsyncEventPending) {
   client->close(folly::none);
 }
 
+static const fizz::test::MockAead *extractMockAead(const quic::Aead* aead) {
+  if (auto fizzAead = dynamic_cast<const FizzAead*>(aead)) {
+    return dynamic_cast<const fizz::test::MockAead*>(fizzAead->getFizzAead());
+  }
+
+  return nullptr;
+}
+
 TEST_F(QuicClientTransportAfterStartTest, StatelessResetClosesTransport) {
   // Make decrypt fail for the reset token
-  auto aead = dynamic_cast<const fizz::test::MockAead*>(
+  auto aead = extractMockAead(
       client->getNonConstConn().readCodec->getOneRttReadCipher());
   ASSERT_TRUE(aead);
 
@@ -3324,7 +3333,7 @@ TEST_F(QuicClientTransportAfterStartTest, StatelessResetClosesTransport) {
 }
 
 TEST_F(QuicClientTransportAfterStartTest, BadStatelessResetWontCloseTransport) {
-  auto aead = dynamic_cast<const fizz::test::MockAead*>(
+  auto aead = extractMockAead(
       client->getNonConstConn().readCodec->getOneRttReadCipher());
   ASSERT_TRUE(aead);
   // Make the decrypt fail

--- a/quic/common/test/TestUtils.cpp
+++ b/quic/common/test/TestUtils.cpp
@@ -281,9 +281,10 @@ void setupCtxWithTestCert(fizz::server::FizzServerContext& ctx) {
   ctx.setCertManager(std::move(certManager));
 }
 
-std::unique_ptr<MockAead> createNoOpAead() {
+template<class T>
+std::unique_ptr<T> createNoOpAeadImpl() {
   // Fake that the handshake has already occured
-  auto aead = std::make_unique<NiceMock<fizz::test::MockAead>>();
+  auto aead = std::make_unique<NiceMock<T>>();
   ON_CALL(*aead, _encrypt(_, _, _))
       .WillByDefault(Invoke([&](auto& buf, auto, auto) {
         if (buf) {
@@ -299,14 +300,20 @@ std::unique_ptr<MockAead> createNoOpAead() {
   ON_CALL(*aead, _tryDecrypt(_, _, _))
       .WillByDefault(
           Invoke([&](auto& buf, auto, auto) { return buf->clone(); }));
-  ON_CALL(*aead, keyLength()).WillByDefault(Return(16));
-  ON_CALL(*aead, ivLength()).WillByDefault(Return(16));
   ON_CALL(*aead, getCipherOverhead()).WillByDefault(Return(0));
   return aead;
 }
 
+std::unique_ptr<MockAead> createNoOpAead() {
+  return createNoOpAeadImpl<MockAead>();
+}
+
 std::unique_ptr<fizz::test::MockAead> createNoOpFizzAead() {
-  return createNoOpAead();
+  // Fake that the handshake has already occured
+  auto aead = createNoOpAeadImpl<fizz::test::MockAead>();
+  ON_CALL(*aead, keyLength()).WillByDefault(Return(16));
+  ON_CALL(*aead, ivLength()).WillByDefault(Return(16));
+  return aead;
 }
 
 std::unique_ptr<PacketNumberCipher> createNoOpHeaderCipher() {

--- a/quic/handshake/Aead.h
+++ b/quic/handshake/Aead.h
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Optional.h>
+#include <folly/io/IOBuf.h>
+
+namespace quic {
+
+struct TrafficKey {
+  std::unique_ptr<folly::IOBuf> key;
+  std::unique_ptr<folly::IOBuf> iv;
+};
+
+/**
+ * Interface for aead algorithms (RFC 5116).
+ */
+class Aead {
+public:
+  virtual ~Aead() = default;
+
+  /**
+   * Encrypts plaintext. Will throw on error.
+   */
+  virtual std::unique_ptr<folly::IOBuf>
+  encrypt(std::unique_ptr<folly::IOBuf> &&plaintext,
+          const folly::IOBuf *associatedData, uint64_t seqNum) const = 0;
+
+  /**
+   * Decrypt ciphertext. Will throw if the ciphertext does not decrypt
+   * successfully.
+   */
+  virtual std::unique_ptr<folly::IOBuf>
+  decrypt(std::unique_ptr<folly::IOBuf> &&ciphertext,
+          const folly::IOBuf *associatedData, uint64_t seqNum) const {
+    auto plaintext =
+        tryDecrypt(std::forward<std::unique_ptr<folly::IOBuf>>(ciphertext),
+                   associatedData, seqNum);
+    if (!plaintext) {
+      throw std::runtime_error("decryption failed");
+    }
+    return std::move(*plaintext);
+  }
+
+  /**
+   * Decrypt ciphertext. Will return none if the ciphertext does not decrypt
+   * successfully. May still throw from errors unrelated to ciphertext.
+   */
+  virtual folly::Optional<std::unique_ptr<folly::IOBuf>>
+  tryDecrypt(std::unique_ptr<folly::IOBuf> &&ciphertext,
+             const folly::IOBuf *associatedData, uint64_t seqNum) const = 0;
+
+  /**
+   * Returns the number of bytes the aead will add to the plaintext (size of
+   * ciphertext - size of plaintext).
+   */
+  virtual size_t getCipherOverhead() const = 0;
+};
+} // namespace quic

--- a/quic/handshake/FizzBridge.h
+++ b/quic/handshake/FizzBridge.h
@@ -9,7 +9,55 @@
 #pragma once
 
 #include <fizz/crypto/aead/Aead.h>
+#include <quic/handshake/Aead.h>
+
+#include <memory>
+#include <utility>
 
 namespace quic {
-using Aead = fizz::Aead;
-}
+
+class FizzAead final : public Aead {
+public:
+  static std::unique_ptr<FizzAead> wrap(std::unique_ptr<fizz::Aead> fizzAeadIn) {
+    if (!fizzAeadIn) {
+      return {};
+    }
+
+    return std::unique_ptr<FizzAead>(new FizzAead(std::move(fizzAeadIn)));
+  }
+
+  /**
+   * Simply forward all calls to fizz::Aead.
+   */
+  std::unique_ptr<folly::IOBuf>
+  encrypt(std::unique_ptr<folly::IOBuf> &&plaintext,
+          const folly::IOBuf *associatedData, uint64_t seqNum) const override {
+    return fizzAead->encrypt(
+        std::forward<std::unique_ptr<folly::IOBuf>>(plaintext), associatedData,
+        seqNum);
+  }
+  std::unique_ptr<folly::IOBuf>
+  decrypt(std::unique_ptr<folly::IOBuf> &&ciphertext,
+          const folly::IOBuf *associatedData, uint64_t seqNum) const override {
+    return fizzAead->decrypt(std::move(ciphertext), associatedData, seqNum);
+  }
+  folly::Optional<std::unique_ptr<folly::IOBuf>>
+  tryDecrypt(std::unique_ptr<folly::IOBuf> &&ciphertext,
+             const folly::IOBuf *associatedData,
+             uint64_t seqNum) const override {
+    return fizzAead->tryDecrypt(std::move(ciphertext), associatedData, seqNum);
+  }
+  size_t getCipherOverhead() const override {
+    return fizzAead->getCipherOverhead();
+  }
+
+  // For testing.
+  const fizz::Aead *getFizzAead() const { return fizzAead.get(); }
+
+private:
+  std::unique_ptr<fizz::Aead> fizzAead;
+  FizzAead(std::unique_ptr<fizz::Aead> fizzAeadIn)
+      : fizzAead(std::move(fizzAeadIn)) {}
+};
+
+} // namespace quic

--- a/quic/handshake/HandshakeLayer.cpp
+++ b/quic/handshake/HandshakeLayer.cpp
@@ -11,6 +11,7 @@
 #include <fizz/crypto/KeyDerivation.h>
 #include <fizz/crypto/Sha256.h>
 #include <fizz/protocol/Factory.h>
+#include <quic/handshake/FizzBridge.h>
 #include <quic/handshake/QuicFizzFactory.h>
 
 namespace quic {
@@ -67,7 +68,7 @@ std::unique_ptr<Aead> makeInitialAead(
 
   fizz::TrafficKey trafficKey = {std::move(key), std::move(iv)};
   aead->setKey(std::move(trafficKey));
-  return aead;
+  return FizzAead::wrap(std::move(aead));
 }
 
 std::unique_ptr<Aead> getClientInitialCipher(

--- a/quic/handshake/HandshakeLayer.h
+++ b/quic/handshake/HandshakeLayer.h
@@ -17,7 +17,7 @@
 #include <quic/QuicConstants.h>
 #include <quic/codec/PacketNumberCipher.h>
 #include <quic/codec/Types.h>
-#include <quic/handshake/FizzBridge.h>
+#include <quic/handshake/Aead.h>
 #include <quic/handshake/QuicFizzFactory.h>
 
 namespace fizz {

--- a/quic/server/handshake/ServerHandshake.cpp
+++ b/quic/server/handshake/ServerHandshake.cpp
@@ -9,6 +9,7 @@
 #include <quic/server/handshake/ServerHandshake.h>
 
 #include <fizz/protocol/Protocol.h>
+#include <quic/handshake/FizzBridge.h>
 #include <quic/state/QuicStreamFunctions.h>
 
 namespace quic {
@@ -92,35 +93,35 @@ std::unique_ptr<Aead> ServerHandshake::getHandshakeWriteCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return std::move(handshakeWriteCipher_);
+  return FizzAead::wrap(std::move(handshakeWriteCipher_));
 }
 
 std::unique_ptr<Aead> ServerHandshake::getHandshakeReadCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return std::move(handshakeReadCipher_);
+  return FizzAead::wrap(std::move(handshakeReadCipher_));
 }
 
 std::unique_ptr<Aead> ServerHandshake::getOneRttWriteCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return std::move(oneRttWriteCipher_);
+  return FizzAead::wrap(std::move(oneRttWriteCipher_));
 }
 
 std::unique_ptr<Aead> ServerHandshake::getOneRttReadCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return std::move(oneRttReadCipher_);
+  return FizzAead::wrap(std::move(oneRttReadCipher_));
 }
 
 std::unique_ptr<Aead> ServerHandshake::getZeroRttReadCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return std::move(zeroRttReadCipher_);
+  return FizzAead::wrap(std::move(zeroRttReadCipher_));
 }
 
 std::unique_ptr<PacketNumberCipher>


### PR DESCRIPTION
This is based on top of #15 .

Now that the codebase have been refactored to use Aead/fizz:Aead and MockAead/fizz::test::MockAead in proper places, it is time to ensures the aren't aliases of each others anymore.

This introduces FizzAead as a wrapper for fizz::Aead that implements quic::Aead and forward all calls. Most of the codebase now uses quic::Aead, which a significant step toward being able to swap it for another implementation.