### PR TITLE
restrictEarlyData: Flagged Transport Settings to Restrict Early Data

### DIFF
--- a/quic/samples/echo/EchoServer.h
+++ b/quic/samples/echo/EchoServer.h
@@ -78,7 +78,7 @@ class EchoServer {
   }
 
   void start() {
-    // Create a SocketAddress and the default or passed in host.
+    // Create a SocketAddress and use the default or passed in host.
     folly::SocketAddress addr1(host_.c_str(), port_);
     addr1.setFromHostPort(host_, port_);
     server_->start(addr1, 0);


### PR DESCRIPTION
In the case where `processPacketData()` detected a retry packet sent from the server, flag the transportSettings on the connection to set `attemptEarlyData` to false to restrict any early data being sent on the connection.