### PR TITLE
Add correct path to sample echo binary in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,15 @@ By default the build script `build_helper.sh` enables the building of test targe
 ## Run a sample client and server
 Building the test targets of `mvfst` (or via `build_helper.sh`) should automatically build the sample client and server binaries as well. The server will automatically bind to `::1` by default if no host is used, but you can then spin a simple echo server by running:
 ```
-./quic/samples/echo -mode=server -host=<host> -port=<port>
+./_build/build/quic/samples/echo -mode=server -host=<host> -port=<port>
 ```
 and to run a client:
 ```
-./quic/samples/echo -mode=client -host=<host> -port=<port>
+./_build/build/quic/samples/echo -mode=client -host=<host> -port=<port>
 ```
 For more options, see
 ```
-./quic/samples/echo --help
+./_build/build/quic/samples/echo --help
 ```
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You might need to run the script as root to install to certain directories.
 By default the build script `build_helper.sh` enables the building of test target (i.e. runs with `-DBUILD_TEST=ON` option). Since some of tests in `mvfst` require some test artifacts of Fizz, it is necessary to supply the path of the Fizz src directory (via option `DFIZZ_PROJECT`) to correctly build all test targets in `mvfst`.
 
 ## Run a sample client and server
-Building the test targets of `mvfst` (or via `build_helper.sh`) should automatically build the sample client and server binaries as well. The server will automatically bind to `::1` by default if no host is used, but you can then spin a simple echo server by running:
+Building the test targets of `mvfst` (or via `build_helper.sh`) should automatically build the sample client and server binaries into the default `_build/build` directory (or whichever target directory was specified). The server will automatically bind to `::1` by default if no host is used, but you can then spin a simple echo server by running:
 ```
 ./_build/build/quic/samples/echo -mode=server -host=<host> -port=<port>
 ```


### PR DESCRIPTION
The current readme uses an incorrect path for the binary built after running `make test`
The current path is to the code directory.
Could lead to potential confusion.