### PR TITLE
Copy of FindGflags.cmake in cmake/ and minor compilation fixes in tests

### DIFF
--- a/cmake/FindGflags.cmake
+++ b/cmake/FindGflags.cmake
@@ -1,0 +1,81 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# Find libgflags.
+# There's a lot of compatibility cruft going on in here, both
+# to deal with changes across the FB consumers of this and also
+# to deal with variances in behavior of cmake itself.
+#
+# Since this file is named FindGflags.cmake the cmake convention
+# is for the module to export both GFLAGS_FOUND and Gflags_FOUND.
+# The convention expected by consumers is that we export the
+# following variables, even though these do not match the cmake
+# conventions:
+#
+#  LIBGFLAGS_INCLUDE_DIR - where to find gflags/gflags.h, etc.
+#  LIBGFLAGS_LIBRARY     - List of libraries when using libgflags.
+#  LIBGFLAGS_FOUND       - True if libgflags found.
+#
+# We need to be able to locate gflags both from an installed
+# cmake config file and just from the raw headers and libs, so
+# test for the former and then the latter, and then stick
+# the results together and export them into the variables
+# listed above.
+#
+# For forwards compatibility, we export the following variables:
+#
+#  gflags_INCLUDE_DIR - where to find gflags/gflags.h, etc.
+#  gflags_TARGET / GFLAGS_TARGET / gflags_LIBRARIES
+#                     - List of libraries when using libgflags.
+#  gflags_FOUND       - True if libgflags found.
+#
+
+IF (LIBGFLAGS_INCLUDE_DIR)
+  # Already in cache, be silent
+  SET(Gflags_FIND_QUIETLY TRUE)
+ENDIF ()
+
+find_package(gflags CONFIG QUIET)
+if (gflags_FOUND)
+  if (NOT Gflags_FIND_QUIETLY)
+    message(STATUS "Found gflags from package config ${gflags_CONFIG}")
+  endif()
+  # Re-export the config-specified libs with our local names
+  set(LIBGFLAGS_LIBRARY ${gflags_LIBRARIES})
+  set(LIBGFLAGS_INCLUDE_DIR ${gflags_INCLUDE_DIR})
+  set(LIBGFLAGS_FOUND ${gflags_FOUND})
+  # cmake module compat
+  set(GFLAGS_FOUND ${gflags_FOUND})
+  set(Gflags_FOUND ${gflags_FOUND})
+else()
+  FIND_PATH(LIBGFLAGS_INCLUDE_DIR gflags/gflags.h)
+
+  FIND_LIBRARY(LIBGFLAGS_LIBRARY_DEBUG NAMES gflagsd gflags_staticd)
+  FIND_LIBRARY(LIBGFLAGS_LIBRARY_RELEASE NAMES gflags gflags_static)
+
+  INCLUDE(SelectLibraryConfigurations)
+  SELECT_LIBRARY_CONFIGURATIONS(LIBGFLAGS)
+
+  # handle the QUIETLY and REQUIRED arguments and set LIBGFLAGS_FOUND to TRUE if
+  # all listed variables are TRUE
+  INCLUDE(FindPackageHandleStandardArgs)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(gflags DEFAULT_MSG LIBGFLAGS_LIBRARY LIBGFLAGS_INCLUDE_DIR)
+  # cmake module compat
+  set(Gflags_FOUND ${GFLAGS_FOUND})
+  # compat with some existing FindGflags consumers
+  set(LIBGFLAGS_FOUND ${GFLAGS_FOUND})
+
+  # Compat with the gflags CONFIG based detection
+  set(gflags_FOUND ${GFLAGS_FOUND})
+  set(gflags_INCLUDE_DIR ${LIBGFLAGS_INCLUDE_DIR})
+  set(gflags_LIBRARIES ${LIBGFLAGS_LIBRARY})
+  set(GFLAGS_TARGET ${LIBGFLAGS_LIBRARY})
+  set(gflags_TARGET ${LIBGFLAGS_LIBRARY})
+
+  MARK_AS_ADVANCED(LIBGFLAGS_LIBRARY LIBGFLAGS_INCLUDE_DIR)
+endif()
+
+# Compat with the gflags CONFIG based detection
+if (LIBGFLAGS_FOUND AND NOT TARGET gflags)
+  add_library(gflags UNKNOWN IMPORTED)
+  set_target_properties(gflags PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBGFLAGS_INCLUDE_DIR}")
+  set_target_properties(gflags PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C" IMPORTED_LOCATION "${LIBGFLAGS_LIBRARY}")
+endif()

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -449,7 +449,7 @@ TEST_P(QuicClientTransportIntegrationTest, TLSAlert) {
         EXPECT_EQ(indices.size(), 1);
         auto tmp = std::move(qLogger->logs[indices[0]]);
         auto event = dynamic_cast<QLogTransportSummaryEvent*>(tmp.get());
-        checkTransportSummaryEvent(event);
+        this->checkTransportSummaryEvent(event);
 
         eventbase_.terminateLoopSoon();
       }));
@@ -480,7 +480,7 @@ TEST_P(QuicClientTransportIntegrationTest, BadServerTest) {
         EXPECT_EQ(indices.size(), 1);
         auto tmp = std::move(qLogger->logs[indices[0]]);
         auto event = dynamic_cast<QLogTransportSummaryEvent*>(tmp.get());
-        checkTransportSummaryEvent(event);
+        this->checkTransportSummaryEvent(event);
       }));
   client->start(&clientConnCallback);
   eventbase_.loop();

--- a/quic/common/test/FunctionLooperTest.cpp
+++ b/quic/common/test/FunctionLooperTest.cpp
@@ -17,6 +17,8 @@ using namespace testing;
 namespace quic {
 namespace test {
 
+class FunctionLooperTest : public ::testing::Test {};
+
 TEST(FunctionLooperTest, LooperNotRunning) {
   EventBase evb;
   bool called = false;
@@ -175,11 +177,11 @@ TEST(FunctionLooperTest, PacingOnce) {
   looper->run();
   evb.loopOnce();
   EXPECT_EQ(1, fromTimerVec.size());
-  EXPECT_EQ(false, fromTimerVec.back());
+  EXPECT_FALSE(fromTimerVec.back());
   EXPECT_TRUE(looper->isScheduled());
   looper->timeoutExpired();
   EXPECT_EQ(2, fromTimerVec.size());
-  EXPECT_EQ(true, fromTimerVec.back());
+  EXPECT_TRUE(fromTimerVec.back());
   looper->stop();
 }
 
@@ -202,21 +204,21 @@ TEST(FunctionLooperTest, KeepPacing) {
   looper->run();
   evb.loopOnce();
   EXPECT_EQ(1, fromTimerVec.size());
-  EXPECT_EQ(false, fromTimerVec.back());
+  EXPECT_FALSE(fromTimerVec.back());
   EXPECT_TRUE(looper->isScheduled());
 
   looper->cancelTimeout();
   EXPECT_FALSE(looper->isScheduled());
   looper->timeoutExpired();
   EXPECT_EQ(2, fromTimerVec.size());
-  EXPECT_EQ(true, fromTimerVec.back());
+  EXPECT_TRUE(fromTimerVec.back());
   EXPECT_TRUE(looper->isScheduled());
 
   looper->cancelTimeout();
   EXPECT_FALSE(looper->isScheduled());
   looper->timeoutExpired();
   EXPECT_EQ(3, fromTimerVec.size());
-  EXPECT_EQ(true, fromTimerVec.back());
+  EXPECT_TRUE(fromTimerVec.back());
   EXPECT_TRUE(looper->isScheduled());
 
   stopPacing = true;
@@ -224,7 +226,7 @@ TEST(FunctionLooperTest, KeepPacing) {
   EXPECT_FALSE(looper->isScheduled());
   looper->timeoutExpired();
   EXPECT_EQ(4, fromTimerVec.size());
-  EXPECT_EQ(true, fromTimerVec.back());
+  EXPECT_TRUE(fromTimerVec.back());
   EXPECT_FALSE(looper->isScheduled());
 
   looper->stop();


### PR DESCRIPTION
On Ubuntu 16.04 cmake 3.10.3 does not find the FindFlags.cmake unless it is copied in the cmake/ directory, which in fact already contains other cmake find scripts.

Changes to unit tests are very minor only to allow compilation with gcc 5.4.0 (not tested with other compilers).