### PR TITLE
Add CryptoFactory to abtract Fizz specific crypto operations

### DIFF
--- a/quic/client/QuicClientTransport.cpp
+++ b/quic/client/QuicClientTransport.cpp
@@ -14,6 +14,7 @@
 #include <quic/client/handshake/ClientTransportParametersExtension.h>
 #include <quic/client/state/ClientStateMachine.h>
 #include <quic/flowcontrol/QuicFlowController.h>
+#include <quic/handshake/FizzCryptoFactory.h>
 #include <quic/happyeyeballs/QuicHappyEyeballsFunctions.h>
 #include <quic/logging/QLoggerConstants.h>
 #include <quic/loss/QuicLossFunctions.h>
@@ -831,11 +832,12 @@ void QuicClientTransport::startCryptoHandshake() {
   }
 
   QuicFizzFactory fizzFactory;
+  FizzCryptoFactory cryptoFactory(&fizzFactory);
   auto version = conn_->originalVersion.value();
-  conn_->initialWriteCipher = getClientInitialCipher(
-      &fizzFactory, *clientConn_->initialDestinationConnectionId, version);
-  conn_->readCodec->setInitialReadCipher(getServerInitialCipher(
-      &fizzFactory, *clientConn_->initialDestinationConnectionId, version));
+  conn_->initialWriteCipher = cryptoFactory.getClientInitialCipher(
+      *clientConn_->initialDestinationConnectionId, version);
+  conn_->readCodec->setInitialReadCipher(cryptoFactory.getServerInitialCipher(
+      *clientConn_->initialDestinationConnectionId, version));
   conn_->readCodec->setInitialHeaderCipher(makeServerInitialHeaderCipher(
       &fizzFactory, *clientConn_->initialDestinationConnectionId, version));
   conn_->initialHeaderCipher = makeClientInitialHeaderCipher(

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -24,6 +24,7 @@
 #include <quic/common/test/TestUtils.h>
 #include <quic/congestion_control/CongestionControllerFactory.h>
 #include <quic/handshake/FizzBridge.h>
+#include <quic/handshake/FizzCryptoFactory.h>
 #include <quic/handshake/TransportParameters.h>
 #include <quic/handshake/test/Mocks.h>
 #include <quic/happyeyeballs/QuicHappyEyeballsFunctions.h>
@@ -1515,12 +1516,11 @@ class QuicClientTransportTest : public Test {
 
   std::unique_ptr<QuicReadCodec> makeHandshakeCodec() {
     QuicFizzFactory fizzFactory;
+    FizzCryptoFactory cryptoFactory(&fizzFactory);
     auto codec = std::make_unique<QuicReadCodec>(QuicNodeType::Server);
     codec->setClientConnectionId(*originalConnId);
-    codec->setInitialReadCipher(getClientInitialCipher(
-        &fizzFactory,
-        *client->getConn().initialDestinationConnectionId,
-        QuicVersion::MVFST));
+    codec->setInitialReadCipher(cryptoFactory.getClientInitialCipher(
+        *client->getConn().initialDestinationConnectionId, QuicVersion::MVFST));
     codec->setInitialHeaderCipher(makeClientInitialHeaderCipher(
         &fizzFactory,
         *client->getConn().initialDestinationConnectionId,
@@ -1533,6 +1533,7 @@ class QuicClientTransportTest : public Test {
   std::unique_ptr<QuicReadCodec> makeEncryptedCodec(
       bool handshakeCipher = false) {
     QuicFizzFactory fizzFactory;
+    FizzCryptoFactory cryptoFactory(&fizzFactory);
     auto codec = std::make_unique<QuicReadCodec>(QuicNodeType::Server);
     std::unique_ptr<Aead> handshakeReadCipher;
     codec->setClientConnectionId(*originalConnId);
@@ -1541,8 +1542,7 @@ class QuicClientTransportTest : public Test {
     codec->setZeroRttReadCipher(test::createNoOpAead());
     codec->setZeroRttHeaderCipher(test::createNoOpHeaderCipher());
     if (handshakeCipher) {
-      codec->setInitialReadCipher(getClientInitialCipher(
-          &fizzFactory,
+      codec->setInitialReadCipher(cryptoFactory.getClientInitialCipher(
           *client->getConn().initialDestinationConnectionId,
           QuicVersion::MVFST));
       codec->setInitialHeaderCipher(makeClientInitialHeaderCipher(
@@ -2530,9 +2530,10 @@ TEST_F(QuicClientTransportAfterStartTest, ReadStreamCoalesced) {
   }));
 
   QuicFizzFactory fizzFactory;
+  FizzCryptoFactory cryptoFactory(&fizzFactory);
   auto garbage = IOBuf::copyBuffer("garbage");
-  auto initialCipher = getServerInitialCipher(
-      &fizzFactory, *serverChosenConnId, QuicVersion::MVFST);
+  auto initialCipher = cryptoFactory.getServerInitialCipher(*serverChosenConnId,
+                                                            QuicVersion::MVFST);
   auto firstPacketNum = appDataPacketNum++;
   auto packet1 = packetToBufCleartext(
       createStreamPacket(
@@ -2579,11 +2580,12 @@ TEST_F(QuicClientTransportAfterStartTest, ReadStreamCoalescedMany) {
   auto expected = IOBuf::copyBuffer("hello");
   EXPECT_CALL(readCb, readAvailable(streamId)).Times(0);
   QuicFizzFactory fizzFactory;
+  FizzCryptoFactory cryptoFactory(&fizzFactory);
   IOBufQueue packets{IOBufQueue::cacheChainLength()};
   for (int i = 0; i < kMaxNumCoalescedPackets; i++) {
     auto garbage = IOBuf::copyBuffer("garbage");
-    auto initialCipher = getServerInitialCipher(
-        &fizzFactory, *serverChosenConnId, QuicVersion::MVFST);
+    auto initialCipher = cryptoFactory.getServerInitialCipher(
+        *serverChosenConnId, QuicVersion::MVFST);
     auto packetNum = appDataPacketNum++;
     auto packet1 = packetToBufCleartext(
         createStreamPacket(
@@ -3260,6 +3262,7 @@ TEST_F(QuicClientTransportAfterStartTest, InvalidStream) {
 
 TEST_F(QuicClientTransportAfterStartTest, WrongCleartextCipher) {
   QuicFizzFactory fizzFactory;
+  FizzCryptoFactory cryptoFactory(&fizzFactory);
   StreamId streamId = client->createBidirectionalStream().value();
 
   auto expected = IOBuf::copyBuffer("hello");
@@ -3267,8 +3270,8 @@ TEST_F(QuicClientTransportAfterStartTest, WrongCleartextCipher) {
   // throws on getting unencrypted stream data.
   PacketNum nextPacketNum = appDataPacketNum++;
 
-  auto initialCipher = getServerInitialCipher(
-      &fizzFactory, *serverChosenConnId, QuicVersion::MVFST);
+  auto initialCipher = cryptoFactory.getServerInitialCipher(*serverChosenConnId,
+                                                            QuicVersion::MVFST);
   auto packet = packetToBufCleartext(
       createStreamPacket(
           *serverChosenConnId /* src */,

--- a/quic/codec/test/QuicReadCodecTest.cpp
+++ b/quic/codec/test/QuicReadCodecTest.cpp
@@ -6,11 +6,12 @@
  *
  */
 
-#include <quic/codec/QuicReadCodec.h>
 #include <folly/io/Cursor.h>
 #include <folly/portability/GTest.h>
 #include <quic/QuicException.h>
+#include <quic/codec/QuicReadCodec.h>
 #include <quic/common/test/TestUtils.h>
+#include <quic/handshake/FizzCryptoFactory.h>
 
 using namespace quic;
 using namespace quic::test;
@@ -45,10 +46,11 @@ std::unique_ptr<QuicReadCodec> makeEncryptedCodec(
     std::unique_ptr<Aead> zeroRttAead = nullptr,
     std::unique_ptr<StatelessResetToken> sourceToken = nullptr) {
   QuicFizzFactory fizzFactory;
+  FizzCryptoFactory cryptoFactory(&fizzFactory);
   auto codec = std::make_unique<QuicReadCodec>(QuicNodeType::Server);
   codec->setClientConnectionId(clientConnId);
   codec->setInitialReadCipher(
-      getClientInitialCipher(&fizzFactory, clientConnId, QuicVersion::MVFST));
+      cryptoFactory.getClientInitialCipher(clientConnId, QuicVersion::MVFST));
   codec->setInitialHeaderCipher(makeClientInitialHeaderCipher(
       &fizzFactory, clientConnId, QuicVersion::MVFST));
   codec->setZeroRttReadCipher(std::move(zeroRttAead));
@@ -456,9 +458,10 @@ TEST_F(QuicReadCodecTest, TestInitialPacket) {
   auto connId = getTestConnectionId();
 
   QuicFizzFactory fizzFactory;
+  FizzCryptoFactory cryptoFactory(&fizzFactory);
   PacketNum packetNum = 1;
   uint64_t offset = 0;
-  auto aead = getClientInitialCipher(&fizzFactory, connId, QuicVersion::MVFST);
+  auto aead = cryptoFactory.getClientInitialCipher(connId, QuicVersion::MVFST);
   auto headerCipher =
       makeClientInitialHeaderCipher(&fizzFactory, connId, QuicVersion::MVFST);
   auto packet = createInitialCryptoPacket(
@@ -471,7 +474,7 @@ TEST_F(QuicReadCodecTest, TestInitialPacket) {
       offset);
 
   auto codec = makeEncryptedCodec(connId, std::move(aead), nullptr);
-  aead = getClientInitialCipher(&fizzFactory, connId, QuicVersion::MVFST);
+  aead = cryptoFactory.getClientInitialCipher(connId, QuicVersion::MVFST);
   AckStates ackStates;
   auto packetQueue =
       bufToQueue(packetToBufCleartext(packet, *aead, *headerCipher, packetNum));
@@ -493,9 +496,10 @@ TEST_F(QuicReadCodecTest, TestHandshakeDone) {
   auto connId = getTestConnectionId();
 
   QuicFizzFactory fizzFactory;
+  FizzCryptoFactory cryptoFactory(&fizzFactory);
   PacketNum packetNum = 1;
   uint64_t offset = 0;
-  auto aead = getClientInitialCipher(&fizzFactory, connId, QuicVersion::MVFST);
+  auto aead = cryptoFactory.getClientInitialCipher(connId, QuicVersion::MVFST);
   auto headerCipher =
       makeClientInitialHeaderCipher(&fizzFactory, connId, QuicVersion::MVFST);
   auto packet = createInitialCryptoPacket(
@@ -508,7 +512,7 @@ TEST_F(QuicReadCodecTest, TestHandshakeDone) {
       offset);
 
   auto codec = makeEncryptedCodec(connId, std::move(aead), nullptr);
-  aead = getClientInitialCipher(&fizzFactory, connId, QuicVersion::MVFST);
+  aead = cryptoFactory.getClientInitialCipher(connId, QuicVersion::MVFST);
   AckStates ackStates;
   auto packetQueue =
       bufToQueue(packetToBufCleartext(packet, *aead, *headerCipher, packetNum));

--- a/quic/handshake/CMakeLists.txt
+++ b/quic/handshake/CMakeLists.txt
@@ -5,7 +5,9 @@
 
 add_library(
   mvfst_handshake STATIC
+  CryptoFactory.cpp
   FizzBridge.cpp
+  FizzCryptoFactory.cpp
   HandshakeLayer.cpp
   QuicFizzFactory.cpp
   TransportParameters.cpp

--- a/quic/handshake/CryptoFactory.cpp
+++ b/quic/handshake/CryptoFactory.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#include <quic/handshake/CryptoFactory.h>
+
+#include <quic/handshake/HandshakeLayer.h>
+
+namespace quic {
+
+std::unique_ptr<Aead> CryptoFactory::getClientInitialCipher(
+    const ConnectionId &clientDestinationConnId, QuicVersion version) const {
+  return makeInitialAead(kClientInitialLabel, clientDestinationConnId, version);
+}
+
+std::unique_ptr<Aead> CryptoFactory::getServerInitialCipher(
+    const ConnectionId &clientDestinationConnId, QuicVersion version) const {
+  return makeInitialAead(kServerInitialLabel, clientDestinationConnId, version);
+}
+
+Buf CryptoFactory::makeServerInitialTrafficSecret(
+    const ConnectionId &clientDestinationConnId, QuicVersion version) const {
+  return makeInitialTrafficSecret(kServerInitialLabel, clientDestinationConnId,
+                                  version);
+}
+
+Buf CryptoFactory::makeClientInitialTrafficSecret(
+    const ConnectionId &clientDestinationConnId, QuicVersion version) const {
+  return makeInitialTrafficSecret(kClientInitialLabel, clientDestinationConnId,
+                                  version);
+}
+
+} // namespace quic

--- a/quic/handshake/CryptoFactory.h
+++ b/quic/handshake/CryptoFactory.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#pragma once
+
+#include <quic/QuicConstants.h>
+#include <quic/codec/QuicConnectionId.h>
+#include <quic/codec/Types.h>
+#include <quic/handshake/Aead.h>
+
+#include <memory>
+
+namespace quic {
+
+class CryptoFactory {
+public:
+  // TODO remove version parameter when we don't need to support MVFST_OLD
+  // anymore.
+  std::unique_ptr<Aead>
+  getClientInitialCipher(const ConnectionId &clientDestinationConnId,
+                         QuicVersion version) const;
+  std::unique_ptr<Aead>
+  getServerInitialCipher(const ConnectionId &clientDestinationConnId,
+                         QuicVersion version) const;
+
+  Buf makeServerInitialTrafficSecret(
+      const ConnectionId &clientDestinationConnId, QuicVersion version) const;
+  Buf makeClientInitialTrafficSecret(
+      const ConnectionId &clientDestinationConnId, QuicVersion version) const;
+
+  /**
+   * Crypto layer specifc methods.
+   */
+  virtual Buf
+  makeInitialTrafficSecret(folly::StringPiece label,
+                           const ConnectionId &clientDestinationConnId,
+                           QuicVersion version) const = 0;
+
+  virtual std::unique_ptr<Aead>
+  makeInitialAead(folly::StringPiece label,
+                  const ConnectionId &clientDestinationConnId,
+                  QuicVersion version) const = 0;
+
+  virtual ~CryptoFactory() {}
+};
+
+} // namespace quic

--- a/quic/handshake/FizzCryptoFactory.cpp
+++ b/quic/handshake/FizzCryptoFactory.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#include <quic/handshake/FizzCryptoFactory.h>
+
+#include <quic/handshake/FizzBridge.h>
+#include <quic/handshake/HandshakeLayer.h>
+
+namespace quic {
+
+Buf FizzCryptoFactory::makeInitialTrafficSecret(
+    folly::StringPiece label, const ConnectionId &clientDestinationConnId,
+    QuicVersion version) const {
+  auto deriver =
+      factory->makeKeyDeriver(fizz::CipherSuite::TLS_AES_128_GCM_SHA256);
+  auto connIdRange = folly::range(clientDestinationConnId);
+  auto salt =
+      version == QuicVersion::MVFST_OLD ? kQuicDraft17Salt : kQuicDraft22Salt;
+  auto initialSecret = deriver->hkdfExtract(salt, connIdRange);
+  auto trafficSecret =
+      deriver->expandLabel(folly::range(initialSecret), label,
+                           folly::IOBuf::create(0), fizz::Sha256::HashLen);
+  return trafficSecret;
+}
+
+std::unique_ptr<Aead>
+FizzCryptoFactory::makeInitialAead(folly::StringPiece label,
+                                   const ConnectionId &clientDestinationConnId,
+                                   QuicVersion version) const {
+  auto trafficSecret =
+      makeInitialTrafficSecret(label, clientDestinationConnId, version);
+  auto deriver =
+      factory->makeKeyDeriver(fizz::CipherSuite::TLS_AES_128_GCM_SHA256);
+  auto aead = factory->makeAead(fizz::CipherSuite::TLS_AES_128_GCM_SHA256);
+  auto key = deriver->expandLabel(trafficSecret->coalesce(), kQuicKeyLabel,
+                                  folly::IOBuf::create(0), aead->keyLength());
+  auto iv = deriver->expandLabel(trafficSecret->coalesce(), kQuicIVLabel,
+                                 folly::IOBuf::create(0), aead->ivLength());
+
+  fizz::TrafficKey trafficKey = {std::move(key), std::move(iv)};
+  aead->setKey(std::move(trafficKey));
+  return FizzAead::wrap(std::move(aead));
+}
+
+} // namespace quic

--- a/quic/handshake/FizzCryptoFactory.h
+++ b/quic/handshake/FizzCryptoFactory.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#pragma once
+
+#include <quic/handshake/CryptoFactory.h>
+
+#include <fizz/protocol/Factory.h>
+
+namespace quic {
+
+class FizzCryptoFactory : public CryptoFactory {
+private:
+  fizz::Factory *factory;
+
+public:
+  FizzCryptoFactory(fizz::Factory *factory) : factory(factory) {}
+
+  Buf makeInitialTrafficSecret(folly::StringPiece label,
+                               const ConnectionId &clientDestinationConnId,
+                               QuicVersion version) const override;
+
+  std::unique_ptr<Aead>
+  makeInitialAead(folly::StringPiece label,
+                  const ConnectionId &clientDestinationConnId,
+                  QuicVersion version) const override;
+};
+
+} // namespace quic

--- a/quic/handshake/HandshakeLayer.h
+++ b/quic/handshake/HandshakeLayer.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <fizz/protocol/Exporter.h>
-#include <fizz/protocol/Factory.h>
 #include <folly/Expected.h>
 
 #include <quic/QuicConstants.h>
@@ -17,10 +15,6 @@
 #include <quic/codec/Types.h>
 #include <quic/handshake/Aead.h>
 #include <quic/handshake/QuicFizzFactory.h>
-
-namespace fizz {
-class Factory;
-}
 
 namespace quic {
 
@@ -45,29 +39,6 @@ constexpr folly::StringPiece kQuicDraft22Salt =
 constexpr folly::StringPiece kClientInitialLabel = "client in";
 constexpr folly::StringPiece kServerInitialLabel = "server in";
 
-// TODO remove version parameter when we don't need to support MVFST_OLD anymore
-std::unique_ptr<Aead> makeInitialAead(
-    fizz::Factory* factory,
-    folly::StringPiece label,
-    const ConnectionId& clientDestinationConnId,
-    QuicVersion version);
-
-std::unique_ptr<Aead> getClientInitialCipher(
-    fizz::Factory* factory,
-    const ConnectionId& clientDestinationConnId,
-    QuicVersion version);
-
-std::unique_ptr<Aead> getServerInitialCipher(
-    fizz::Factory* factory,
-    const ConnectionId& clientDestinationConnId,
-    QuicVersion version);
-
-Buf makeInitialTrafficSecret(
-    fizz::Factory* factory,
-    folly::StringPiece label,
-    const ConnectionId& clientDestinationConnId,
-    QuicVersion version);
-
 /**
  * Makes the header cipher for writing client initial packets.
  */
@@ -82,16 +53,6 @@ std::unique_ptr<PacketNumberCipher> makeClientInitialHeaderCipher(
 std::unique_ptr<PacketNumberCipher> makeServerInitialHeaderCipher(
     QuicFizzFactory* factory,
     const ConnectionId& initialDestinationConnectionId,
-    QuicVersion version);
-
-Buf makeServerInitialTrafficSecret(
-    fizz::Factory* factory,
-    const ConnectionId& clientDestinationConnId,
-    QuicVersion version);
-
-Buf makeClientInitialTrafficSecret(
-    fizz::Factory* factory,
-    const ConnectionId& clientDestinationConnId,
     QuicVersion version);
 
 std::unique_ptr<PacketNumberCipher> makePacketNumberCipher(

--- a/quic/handshake/test/CMakeLists.txt
+++ b/quic/handshake/test/CMakeLists.txt
@@ -25,3 +25,13 @@ quic_add_test(TARGET HandshakeLayerTest
   mvfst_handshake
   mvfst_test_utils
 )
+
+quic_add_test(TARGET FizzCryptoFactoryTest
+  SOURCES
+  FizzCryptoFactoryTest.cpp
+  DEPENDS
+  Folly::folly
+  mvfst_handshake
+  mvfst_test_utils
+)
+

--- a/quic/handshake/test/FizzCryptoFactoryTest.cpp
+++ b/quic/handshake/test/FizzCryptoFactoryTest.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <quic/common/test/TestUtils.h>
+#include <quic/handshake/FizzCryptoFactory.h>
+#include <quic/handshake/QuicFizzFactory.h>
+#include <quic/handshake/test/Mocks.h>
+
+using namespace folly;
+using namespace testing;
+
+namespace quic {
+namespace test {
+
+class QuicTestFizzFactory : public QuicFizzFactory {
+public:
+  ~QuicTestFizzFactory() override = default;
+
+  std::unique_ptr<fizz::Aead> makeAead(fizz::CipherSuite) const override {
+    return std::move(aead_);
+  }
+
+  void setMockAead(std::unique_ptr<fizz::Aead> aead) {
+    aead_ = std::move(aead);
+  }
+
+  mutable std::unique_ptr<fizz::Aead> aead_;
+};
+
+class FizzCryptoFactoryTest : public Test {
+public:
+  std::unique_ptr<fizz::test::MockAead> createMockAead() {
+    auto mockAead = std::make_unique<StrictMock<fizz::test::MockAead>>();
+    EXPECT_CALL(*mockAead, _setKey(_)).WillOnce(Invoke([&](auto &trafficKey) {
+      trafficKey_ = std::move(trafficKey);
+    }));
+    EXPECT_CALL(*mockAead, keyLength())
+        .WillRepeatedly(Return(fizz::AESGCM128::kKeyLength));
+    EXPECT_CALL(*mockAead, ivLength())
+        .WillRepeatedly(Return(fizz::AESGCM128::kIVLength));
+    return mockAead;
+  }
+
+  folly::Optional<fizz::TrafficKey> trafficKey_;
+};
+
+TEST_F(FizzCryptoFactoryTest, TestDraft17ClearTextCipher) {
+  // test vector taken from
+  // https://github.com/quicwg/base-drafts/wiki/Test-Vector-for-the-Clear-Text-AEAD-key-derivation
+  auto connid = folly::unhexlify("c654efd8a31b4792");
+  std::vector<uint8_t> destinationConnidVector;
+  for (size_t i = 0; i < connid.size(); ++i) {
+    destinationConnidVector.push_back(connid.data()[i]);
+  }
+  ConnectionId destinationConnid(destinationConnidVector);
+  QuicTestFizzFactory fizzFactory;
+  fizzFactory.setMockAead(createMockAead());
+  FizzCryptoFactory cryptoFactory(&fizzFactory);
+  auto aead = cryptoFactory.getClientInitialCipher(destinationConnid,
+                                                   QuicVersion::MVFST_OLD);
+
+  std::string expectedKey = "86d1830480b40f86cf9d68dcadf35dfe";
+  std::string expectedIv = "12f3938aca34aa02543163d4";
+  auto trafficKeyHex = folly::hexlify(trafficKey_->key->coalesce());
+  auto trafficIvHex = folly::hexlify(trafficKey_->iv->coalesce());
+  EXPECT_EQ(trafficKeyHex, expectedKey);
+  EXPECT_EQ(trafficIvHex, expectedIv);
+}
+
+} // namespace test
+} // namespace quic

--- a/quic/server/state/ServerStateMachine.cpp
+++ b/quic/server/state/ServerStateMachine.cpp
@@ -10,6 +10,7 @@
 
 #include <quic/congestion_control/CongestionControllerFactory.h>
 #include <quic/flowcontrol/QuicFlowController.h>
+#include <quic/handshake/FizzCryptoFactory.h>
 #include <quic/handshake/TransportParameters.h>
 #include <quic/logging/QLoggerConstants.h>
 #include <quic/state/QuicPacingFunctions.h>
@@ -486,8 +487,9 @@ void onServerReadDataFromOpen(
             token));
     QuicFizzFactory fizzFactory;
     conn.readCodec = std::make_unique<QuicReadCodec>(QuicNodeType::Server);
-    conn.readCodec->setInitialReadCipher(getClientInitialCipher(
-        &fizzFactory, initialDestinationConnectionId, version));
+    conn.readCodec->setInitialReadCipher(
+        FizzCryptoFactory(&fizzFactory)
+            .getClientInitialCipher(initialDestinationConnectionId, version));
     conn.readCodec->setClientConnectionId(clientConnectionId);
     if (conn.qLogger) {
       conn.qLogger->scid = conn.serverConnectionId;
@@ -495,8 +497,9 @@ void onServerReadDataFromOpen(
     }
     conn.readCodec->setCodecParameters(
         CodecParameters(conn.peerAckDelayExponent, version));
-    conn.initialWriteCipher = getServerInitialCipher(
-        &fizzFactory, initialDestinationConnectionId, version);
+    conn.initialWriteCipher =
+        FizzCryptoFactory(&fizzFactory)
+            .getServerInitialCipher(initialDestinationConnectionId, version);
 
     conn.readCodec->setInitialHeaderCipher(makeClientInitialHeaderCipher(
         &fizzFactory, initialDestinationConnectionId, version));

--- a/quic/server/test/QuicServerTransportTest.cpp
+++ b/quic/server/test/QuicServerTransportTest.cpp
@@ -19,6 +19,7 @@
 #include <quic/codec/Types.h>
 #include <quic/common/test/TestUtils.h>
 #include <quic/congestion_control/CongestionControllerFactory.h>
+#include <quic/handshake/FizzCryptoFactory.h>
 #include <quic/logging/FileQLogger.h>
 #include <quic/server/handshake/ServerHandshake.h>
 #include <quic/server/test/Mocks.h>
@@ -322,8 +323,9 @@ class QuicServerTransportTest : public Test {
 
   std::unique_ptr<Aead> getInitialCipher() {
     QuicFizzFactory fizzFactory;
-    return getClientInitialCipher(
-        &fizzFactory, *initialDestinationConnectionId, QuicVersion::MVFST);
+    FizzCryptoFactory cryptoFactory(&fizzFactory);
+    return cryptoFactory.getClientInitialCipher(*initialDestinationConnectionId,
+                                                QuicVersion::MVFST);
   }
 
   std::unique_ptr<PacketNumberCipher> getInitialHeaderCipher() {
@@ -405,10 +407,11 @@ class QuicServerTransportTest : public Test {
 
   virtual void setupClientReadCodec() {
     QuicFizzFactory fizzFactory;
+    FizzCryptoFactory cryptoFactory(&fizzFactory);
     clientReadCodec = std::make_unique<QuicReadCodec>(QuicNodeType::Client);
     clientReadCodec->setClientConnectionId(*clientConnectionId);
-    clientReadCodec->setInitialReadCipher(getServerInitialCipher(
-        &fizzFactory, *initialDestinationConnectionId, QuicVersion::MVFST));
+    clientReadCodec->setInitialReadCipher(cryptoFactory.getServerInitialCipher(
+        *initialDestinationConnectionId, QuicVersion::MVFST));
     clientReadCodec->setInitialHeaderCipher(makeServerInitialHeaderCipher(
         &fizzFactory, *initialDestinationConnectionId, QuicVersion::MVFST));
     clientReadCodec->setCodecParameters(
@@ -575,6 +578,7 @@ class QuicServerTransportTest : public Test {
   std::unique_ptr<QuicReadCodec> makeClientEncryptedCodec(
       bool handshakeCipher = false) {
     QuicFizzFactory fizzFactory;
+    FizzCryptoFactory cryptoFactory(&fizzFactory);
     auto readCodec = std::make_unique<QuicReadCodec>(QuicNodeType::Client);
     readCodec->setOneRttReadCipher(test::createNoOpAead());
     readCodec->setOneRttHeaderCipher(test::createNoOpHeaderCipher());
@@ -584,8 +588,8 @@ class QuicServerTransportTest : public Test {
     readCodec->setCodecParameters(
         CodecParameters(kDefaultAckDelayExponent, QuicVersion::MVFST));
     if (handshakeCipher) {
-      readCodec->setInitialReadCipher(getServerInitialCipher(
-          &fizzFactory, *initialDestinationConnectionId, QuicVersion::MVFST));
+      readCodec->setInitialReadCipher(cryptoFactory.getServerInitialCipher(
+          *initialDestinationConnectionId, QuicVersion::MVFST));
       readCodec->setInitialHeaderCipher(makeServerInitialHeaderCipher(
           &fizzFactory, *initialDestinationConnectionId, QuicVersion::MVFST));
     }
@@ -2789,9 +2793,10 @@ TEST_F(QuicUnencryptedServerTransportTest, TestBadPacketProtectionLevel) {
 
 TEST_F(QuicUnencryptedServerTransportTest, TestBadCleartextEncryption) {
   QuicFizzFactory fizzFactory;
+  FizzCryptoFactory cryptoFactory(&fizzFactory);
   PacketNum nextPacket = clientNextInitialPacketNum++;
-  auto aead = getServerInitialCipher(
-      &fizzFactory, *clientConnectionId, QuicVersion::MVFST);
+  auto aead = cryptoFactory.getServerInitialCipher(*clientConnectionId,
+                                                   QuicVersion::MVFST);
   auto packetData = packetToBufCleartext(
       createInitialCryptoPacket(
           *clientConnectionId,


### PR DESCRIPTION
This introduce the CryptoFactory abstraction that compute keys and AEAD to be used by most of mvfst.

The fizz specific parts are abstracted into a subclass, FizzCryptoFactory, and accessed using virtual methods.

Next step is to introduce QuicFizzFactory 's features into this abstraction.