### PR TITLE
Update ClientHandshake to use a quic::Aead instead of fizz:Aead as soon as possible.

### DIFF
--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -96,35 +96,35 @@ std::unique_ptr<Aead> ClientHandshake::getOneRttWriteCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return FizzAead::wrap(std::move(oneRttWriteCipher_));
+  return std::move(oneRttWriteCipher_);
 }
 
 std::unique_ptr<Aead> ClientHandshake::getOneRttReadCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return FizzAead::wrap(std::move(oneRttReadCipher_));
+  return std::move(oneRttReadCipher_);
 }
 
 std::unique_ptr<Aead> ClientHandshake::getZeroRttWriteCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return FizzAead::wrap(std::move(zeroRttWriteCipher_));
+  return std::move(zeroRttWriteCipher_);
 }
 
 std::unique_ptr<Aead> ClientHandshake::getHandshakeReadCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return FizzAead::wrap(std::move(handshakeReadCipher_));
+  return std::move(handshakeReadCipher_);
 }
 
 std::unique_ptr<Aead> ClientHandshake::getHandshakeWriteCipher() {
   if (error_) {
     error_.throw_exception();
   }
-  return FizzAead::wrap(std::move(handshakeWriteCipher_));
+  return std::move(handshakeWriteCipher_);
 }
 
 std::unique_ptr<PacketNumberCipher>
@@ -339,13 +339,10 @@ void ClientHandshake::ActionMoveVisitor::operator()(
                 client_.state_.context()->getFactory()->makeKeyScheduler(
                     cipher);
             client_.zeroRttWriteCipher_ =
-                fizz::Protocol::deriveRecordAeadWithLabel(
-                    *client_.state_.context()->getFactory(),
-                    *keyScheduler,
-                    cipher,
-                    folly::range(secretAvailable.secret.secret),
-                    kQuicKeyLabel,
-                    kQuicIVLabel);
+                FizzAead::wrap(fizz::Protocol::deriveRecordAeadWithLabel(
+                    *client_.state_.context()->getFactory(), *keyScheduler,
+                    cipher, folly::range(secretAvailable.secret.secret),
+                    kQuicKeyLabel, kQuicIVLabel));
             client_.zeroRttWriteHeaderCipher_ = makePacketNumberCipher(
                 &factory, folly::range(secretAvailable.secret.secret), cipher);
             break;
@@ -368,11 +365,11 @@ void ClientHandshake::ActionMoveVisitor::operator()(
             *client_.state_.cipher());
         switch (handshakeSecrets) {
           case fizz::HandshakeSecrets::ClientHandshakeTraffic:
-            client_.handshakeWriteCipher_ = std::move(aead);
+            client_.handshakeWriteCipher_ = FizzAead::wrap(std::move(aead));
             client_.handshakeWriteHeaderCipher_ = std::move(headerCipher);
             break;
           case fizz::HandshakeSecrets::ServerHandshakeTraffic:
-            client_.handshakeReadCipher_ = std::move(aead);
+            client_.handshakeReadCipher_ = FizzAead::wrap(std::move(aead));
             client_.handshakeReadHeaderCipher_ = std::move(headerCipher);
             break;
         }
@@ -391,11 +388,11 @@ void ClientHandshake::ActionMoveVisitor::operator()(
             *client_.state_.cipher());
         switch (appSecrets) {
           case fizz::AppTrafficSecrets::ClientAppTraffic:
-            client_.oneRttWriteCipher_ = std::move(aead);
+            client_.oneRttWriteCipher_ = FizzAead::wrap(std::move(aead));
             client_.oneRttWriteHeaderCipher_ = std::move(appHeaderCipher);
             break;
           case fizz::AppTrafficSecrets::ServerAppTraffic:
-            client_.oneRttReadCipher_ = std::move(aead);
+            client_.oneRttReadCipher_ = FizzAead::wrap(std::move(aead));
             client_.oneRttReadHeaderCipher_ = std::move(appHeaderCipher);
             break;
         }

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -183,11 +183,11 @@ class ClientHandshake : public Handshake {
   // in the stream.
   Phase phase_{Phase::Initial};
 
-  std::unique_ptr<fizz::Aead> handshakeWriteCipher_;
-  std::unique_ptr<fizz::Aead> handshakeReadCipher_;
-  std::unique_ptr<fizz::Aead> oneRttReadCipher_;
-  std::unique_ptr<fizz::Aead> oneRttWriteCipher_;
-  std::unique_ptr<fizz::Aead> zeroRttWriteCipher_;
+  std::unique_ptr<Aead> handshakeWriteCipher_;
+  std::unique_ptr<Aead> handshakeReadCipher_;
+  std::unique_ptr<Aead> oneRttReadCipher_;
+  std::unique_ptr<Aead> oneRttWriteCipher_;
+  std::unique_ptr<Aead> zeroRttWriteCipher_;
 
   std::unique_ptr<PacketNumberCipher> oneRttReadHeaderCipher_;
   std::unique_ptr<PacketNumberCipher> oneRttWriteHeaderCipher_;

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -23,7 +23,6 @@
 #include <quic/codec/DefaultConnectionIdAlgo.h>
 #include <quic/common/test/TestUtils.h>
 #include <quic/congestion_control/CongestionControllerFactory.h>
-#include <quic/handshake/FizzBridge.h>
 #include <quic/handshake/FizzCryptoFactory.h>
 #include <quic/handshake/TransportParameters.h>
 #include <quic/handshake/test/Mocks.h>
@@ -1127,24 +1126,23 @@ class FakeOneRttHandshakeLayer : public ClientHandshake {
     params_ = std::move(params);
   }
 
-  void setOneRttWriteCipher(std::unique_ptr<fizz::Aead> oneRttWriteCipher) {
+  void setOneRttWriteCipher(std::unique_ptr<Aead> oneRttWriteCipher) {
     oneRttWriteCipher_ = std::move(oneRttWriteCipher);
   }
 
-  void setOneRttReadCipher(std::unique_ptr<fizz::Aead> oneRttReadCipher) {
+  void setOneRttReadCipher(std::unique_ptr<Aead> oneRttReadCipher) {
     oneRttReadCipher_ = std::move(oneRttReadCipher);
   }
 
-  void setHandshakeReadCipher(std::unique_ptr<fizz::Aead> handshakeReadCipher) {
+  void setHandshakeReadCipher(std::unique_ptr<Aead> handshakeReadCipher) {
     handshakeReadCipher_ = std::move(handshakeReadCipher);
   }
 
-  void setHandshakeWriteCipher(
-      std::unique_ptr<fizz::Aead> handshakeWriteCipher) {
+  void setHandshakeWriteCipher(std::unique_ptr<Aead> handshakeWriteCipher) {
     handshakeWriteCipher_ = std::move(handshakeWriteCipher);
   }
 
-  void setZeroRttWriteCipher(std::unique_ptr<fizz::Aead> zeroRttWriteCipher) {
+  void setZeroRttWriteCipher(std::unique_ptr<Aead> zeroRttWriteCipher) {
     zeroRttWriteCipher_ = std::move(zeroRttWriteCipher);
   }
 
@@ -1250,10 +1248,10 @@ class QuicClientTransportTest : public Test {
   }
 
   virtual void setFakeHandshakeCiphers() {
-    auto readAead = test::createNoOpFizzAead();
-    auto writeAead = test::createNoOpFizzAead();
-    auto handshakeReadAead = test::createNoOpFizzAead();
-    auto handshakeWriteAead = test::createNoOpFizzAead();
+    auto readAead = test::createNoOpAead();
+    auto writeAead = test::createNoOpAead();
+    auto handshakeReadAead = test::createNoOpAead();
+    auto handshakeWriteAead = test::createNoOpAead();
     mockClientHandshake->setHandshakeReadCipher(std::move(handshakeReadAead));
     mockClientHandshake->setHandshakeWriteCipher(std::move(handshakeWriteAead));
     mockClientHandshake->setOneRttReadCipher(std::move(readAead));
@@ -3573,17 +3571,9 @@ TEST_F(QuicClientTransportAfterStartTest, SwitchEvbWhileAsyncEventPending) {
   client->close(folly::none);
 }
 
-static const fizz::test::MockAead* extractMockAead(const quic::Aead* aead) {
-  if (auto fizzAead = dynamic_cast<const FizzAead*>(aead)) {
-    return dynamic_cast<const fizz::test::MockAead*>(fizzAead->getFizzAead());
-  }
-
-  return nullptr;
-}
-
 TEST_F(QuicClientTransportAfterStartTest, StatelessResetClosesTransport) {
   // Make decrypt fail for the reset token
-  auto aead = extractMockAead(
+  auto aead = dynamic_cast<const MockAead *>(
       client->getNonConstConn().readCodec->getOneRttReadCipher());
   ASSERT_TRUE(aead);
 
@@ -3602,7 +3592,7 @@ TEST_F(QuicClientTransportAfterStartTest, StatelessResetClosesTransport) {
 }
 
 TEST_F(QuicClientTransportAfterStartTest, BadStatelessResetWontCloseTransport) {
-  auto aead = extractMockAead(
+  auto aead = dynamic_cast<const MockAead *>(
       client->getNonConstConn().readCodec->getOneRttReadCipher());
   ASSERT_TRUE(aead);
   // Make the decrypt fail
@@ -4375,11 +4365,11 @@ class QuicZeroRttClientTest : public QuicClientTransportAfterStartTest {
   ~QuicZeroRttClientTest() override = default;
 
   void setFakeHandshakeCiphers() override {
-    auto readAead = test::createNoOpFizzAead();
-    auto writeAead = test::createNoOpFizzAead();
-    auto zeroAead = test::createNoOpFizzAead();
-    auto handshakeReadAead = test::createNoOpFizzAead();
-    auto handshakeWriteAead = test::createNoOpFizzAead();
+    auto readAead = test::createNoOpAead();
+    auto writeAead = test::createNoOpAead();
+    auto zeroAead = test::createNoOpAead();
+    auto handshakeReadAead = test::createNoOpAead();
+    auto handshakeWriteAead = test::createNoOpAead();
     mockClientHandshake->setOneRttReadCipher(std::move(readAead));
     mockClientHandshake->setOneRttWriteCipher(std::move(writeAead));
     mockClientHandshake->setZeroRttWriteCipher(std::move(zeroAead));


### PR DESCRIPTION
Wrap the fizz::Aead as soon as fizz and it over to mvfst and use a quic::Aead everywhere else in ClientHandshake.