### PR TITLE
quic/codec: fix unsigned-signed comparison errors

### DIFF
--- a/quic/codec/Decode.cpp
+++ b/quic/codec/Decode.cpp
@@ -123,7 +123,8 @@ ReadAckFrame decodeAckFrame(
   uint64_t adjustedAckDelay = ackDelay->first << ackDelayExponentToUse;
   if (UNLIKELY(
           adjustedAckDelay >
-          std::numeric_limits<std::chrono::microseconds::rep>::max())) {
+          static_cast<uint64_t>(
+              std::numeric_limits<std::chrono::microseconds::rep>::max()))) {
     throw QuicTransportException(
         "Bad ack delay",
         quic::TransportErrorCode::FRAME_ENCODING_ERROR,

--- a/quic/codec/PacketNumberCipher.cpp
+++ b/quic/codec/PacketNumberCipher.cpp
@@ -119,7 +119,7 @@ HeaderProtectionMask Aes128PacketNumberCipher::mask(
           &outLen,
           sample.data(),
           sample.size()) != 1 ||
-      outLen != outMask.size()) {
+      static_cast<HeaderProtectionMask::size_type>(outLen) != outMask.size()) {
     throw std::runtime_error("Encryption error");
   }
   return outMask;


### PR DESCRIPTION
Compiling mvfst on Arch Linux (GCC 9.1.0) results in `sign-compare` warnings/errors.

```
Decode.cpp:125:28: error: comparison of integer expressions of different signedness: ‘uint64_t’ {aka ‘long unsigned int’} and ‘long int’ [-Werror=sign-compare]
  125 |           adjustedAckDelay >
      |           ~~~~~~~~~~~~~~~~~^
  126 |           std::numeric_limits<std::chrono::microseconds::rep>::max())) {
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


PacketNumberCipher.cpp:122:14: error: comparison of integer expressions of different signedness: ‘int’ and ‘std::array<unsigned char, 16>::size_type’ {aka ‘long unsigned int’} [-Werror=sign-compare]
  122 |       outLen != outMask.size()) {
      |       ~~~~~~~^~~~~~~~~~~~~~~~~
```

Both `outLen` (`EVP_EncryptUpdate() == 1`) and `std::chrono::microseconds::rep>::max` are guaranteed to be non-negative, so I've used `static_cast<unsigned>()` on them.