### PR TITLE
Cleanup support to create mock of fizz:Aead as it is not required anymore.

### DIFF
--- a/quic/common/test/TestUtils.cpp
+++ b/quic/common/test/TestUtils.cpp
@@ -309,14 +309,6 @@ std::unique_ptr<MockAead> createNoOpAead() {
   return createNoOpAeadImpl<MockAead>();
 }
 
-std::unique_ptr<fizz::test::MockAead> createNoOpFizzAead() {
-  // Fake that the handshake has already occured
-  auto aead = createNoOpAeadImpl<fizz::test::MockAead>();
-  ON_CALL(*aead, keyLength()).WillByDefault(Return(16));
-  ON_CALL(*aead, ivLength()).WillByDefault(Return(16));
-  return aead;
-}
-
 std::unique_ptr<PacketNumberCipher> createNoOpHeaderCipher() {
   auto headerCipher = std::make_unique<NiceMock<MockPacketNumberCipher>>();
   ON_CALL(*headerCipher, mask(_)).WillByDefault(Return(HeaderProtectionMask{}));

--- a/quic/common/test/TestUtils.h
+++ b/quic/common/test/TestUtils.h
@@ -19,7 +19,6 @@
 #include <quic/state/StateData.h>
 
 #include <fizz/client/FizzClientContext.h>
-#include <fizz/crypto/aead/test/Mocks.h>
 #include <fizz/server/FizzServerContext.h>
 #include <folly/io/async/test/MockAsyncUDPSocket.h>
 
@@ -138,7 +137,6 @@ QuicCachedPsk setupZeroRttOnClientCtx(
     QuicVersion version);
 
 std::unique_ptr<MockAead> createNoOpAead();
-std::unique_ptr<fizz::test::MockAead> createNoOpFizzAead();
 
 std::unique_ptr<PacketNumberCipher> createNoOpHeaderCipher();
 

--- a/quic/handshake/test/FizzCryptoFactoryTest.cpp
+++ b/quic/handshake/test/FizzCryptoFactoryTest.cpp
@@ -9,6 +9,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <fizz/crypto/aead/test/Mocks.h>
 #include <quic/common/test/TestUtils.h>
 #include <quic/handshake/FizzCryptoFactory.h>
 #include <quic/handshake/QuicFizzFactory.h>

--- a/quic/handshake/test/HandshakeLayerTest.cpp
+++ b/quic/handshake/test/HandshakeLayerTest.cpp
@@ -9,6 +9,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <fizz/crypto/aead/test/Mocks.h>
 #include <quic/codec/QuicConnectionId.h>
 #include <quic/common/test/TestUtils.h>
 #include <quic/handshake/HandshakeLayer.h>

--- a/quic/server/handshake/ServerHandshake.cpp
+++ b/quic/server/handshake/ServerHandshake.cpp
@@ -94,35 +94,35 @@ std::unique_ptr<Aead> ServerHandshake::getHandshakeWriteCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return FizzAead::wrap(std::move(handshakeWriteCipher_));
+  return std::move(handshakeWriteCipher_);
 }
 
 std::unique_ptr<Aead> ServerHandshake::getHandshakeReadCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return FizzAead::wrap(std::move(handshakeReadCipher_));
+  return std::move(handshakeReadCipher_);
 }
 
 std::unique_ptr<Aead> ServerHandshake::getOneRttWriteCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return FizzAead::wrap(std::move(oneRttWriteCipher_));
+  return std::move(oneRttWriteCipher_);
 }
 
 std::unique_ptr<Aead> ServerHandshake::getOneRttReadCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return FizzAead::wrap(std::move(oneRttReadCipher_));
+  return std::move(oneRttReadCipher_);
 }
 
 std::unique_ptr<Aead> ServerHandshake::getZeroRttReadCipher() {
   if (error_) {
     throw QuicTransportException(error_->first, error_->second);
   }
-  return FizzAead::wrap(std::move(zeroRttReadCipher_));
+  return std::move(zeroRttReadCipher_);
 }
 
 std::unique_ptr<PacketNumberCipher>
@@ -410,7 +410,7 @@ void ServerHandshake::ActionMoveVisitor::operator()(
       [&](fizz::EarlySecrets earlySecrets) {
         switch (earlySecrets) {
           case fizz::EarlySecrets::ClientEarlyTraffic:
-            server_.zeroRttReadCipher_ = std::move(aead);
+            server_.zeroRttReadCipher_ = FizzAead::wrap(std::move(aead));
             server_.zeroRttReadHeaderCipher_ = std::move(headerCipher);
             break;
           default:
@@ -420,11 +420,11 @@ void ServerHandshake::ActionMoveVisitor::operator()(
       [&](fizz::HandshakeSecrets handshakeSecrets) {
         switch (handshakeSecrets) {
           case fizz::HandshakeSecrets::ClientHandshakeTraffic:
-            server_.handshakeReadCipher_ = std::move(aead);
+            server_.handshakeReadCipher_ = FizzAead::wrap(std::move(aead));
             server_.handshakeReadHeaderCipher_ = std::move(headerCipher);
             break;
           case fizz::HandshakeSecrets::ServerHandshakeTraffic:
-            server_.handshakeWriteCipher_ = std::move(aead);
+            server_.handshakeWriteCipher_ = FizzAead::wrap(std::move(aead));
             server_.handshakeWriteHeaderCipher_ = std::move(headerCipher);
             break;
         }
@@ -432,11 +432,11 @@ void ServerHandshake::ActionMoveVisitor::operator()(
       [&](fizz::AppTrafficSecrets appSecrets) {
         switch (appSecrets) {
           case fizz::AppTrafficSecrets::ClientAppTraffic:
-            server_.oneRttReadCipher_ = std::move(aead);
+            server_.oneRttReadCipher_ = FizzAead::wrap(std::move(aead));
             server_.oneRttReadHeaderCipher_ = std::move(headerCipher);
             break;
           case fizz::AppTrafficSecrets::ServerAppTraffic:
-            server_.oneRttWriteCipher_ = std::move(aead);
+            server_.oneRttWriteCipher_ = FizzAead::wrap(std::move(aead));
             server_.oneRttWriteHeaderCipher_ = std::move(headerCipher);
             break;
         }
@@ -444,4 +444,5 @@ void ServerHandshake::ActionMoveVisitor::operator()(
       [&](auto) {});
   server_.handshakeEventAvailable_ = true;
 }
+
 } // namespace quic

--- a/quic/server/handshake/ServerHandshake.h
+++ b/quic/server/handshake/ServerHandshake.h
@@ -264,11 +264,11 @@ class ServerHandshake : public Handshake {
   HandshakeCallback* callback_{nullptr};
   folly::Optional<std::pair<std::string, TransportErrorCode>> error_;
 
-  std::unique_ptr<fizz::Aead> handshakeReadCipher_;
-  std::unique_ptr<fizz::Aead> handshakeWriteCipher_;
-  std::unique_ptr<fizz::Aead> oneRttReadCipher_;
-  std::unique_ptr<fizz::Aead> oneRttWriteCipher_;
-  std::unique_ptr<fizz::Aead> zeroRttReadCipher_;
+  std::unique_ptr<Aead> handshakeReadCipher_;
+  std::unique_ptr<Aead> handshakeWriteCipher_;
+  std::unique_ptr<Aead> oneRttReadCipher_;
+  std::unique_ptr<Aead> oneRttWriteCipher_;
+  std::unique_ptr<Aead> zeroRttReadCipher_;
 
   std::unique_ptr<PacketNumberCipher> oneRttReadHeaderCipher_;
   std::unique_ptr<PacketNumberCipher> oneRttWriteHeaderCipher_;

--- a/quic/server/test/QuicServerTransportTest.cpp
+++ b/quic/server/test/QuicServerTransportTest.cpp
@@ -136,9 +136,9 @@ class FakeServerHandshake : public ServerHandshake {
   }
 
   void setEarlyKeys() {
-    oneRttWriteCipher_ = createNoOpFizzAead();
+    oneRttWriteCipher_ = createNoOpAead();
     oneRttWriteHeaderCipher_ = createNoOpHeaderCipher();
-    zeroRttReadCipher_ = createNoOpFizzAead();
+    zeroRttReadCipher_ = createNoOpAead();
     zeroRttReadHeaderCipher_ = createNoOpHeaderCipher();
   }
 
@@ -146,17 +146,17 @@ class FakeServerHandshake : public ServerHandshake {
     // Mimic ServerHandshake behavior.
     // oneRttWriteCipher would already be set during ReportEarlyHandshakeSuccess
     if (!allowZeroRttKeys_) {
-      oneRttWriteCipher_ = createNoOpFizzAead();
+      oneRttWriteCipher_ = createNoOpAead();
       oneRttWriteHeaderCipher_ = createNoOpHeaderCipher();
     }
-    oneRttReadCipher_ = createNoOpFizzAead();
+    oneRttReadCipher_ = createNoOpAead();
     oneRttReadHeaderCipher_ = createNoOpHeaderCipher();
   }
 
   void setHandshakeKeys() {
-    handshakeWriteCipher_ = createNoOpFizzAead();
+    handshakeWriteCipher_ = createNoOpAead();
     handshakeWriteHeaderCipher_ = createNoOpHeaderCipher();
-    handshakeReadCipher_ = createNoOpFizzAead();
+    handshakeReadCipher_ = createNoOpAead();
     handshakeReadHeaderCipher_ = createNoOpHeaderCipher();
   }
 


### PR DESCRIPTION
After #35 , the facility to mock fizz::Aead is not required anymore. Either the test depends on fizz's behavior, in which case a mock was never appropriate, or it doesn, in which case a quic::Aead is more appropriate.