### PR TITLE
Remove unused fizzClientContext_ member from ClientHandshake

### DIFF
--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -221,7 +221,6 @@ class ClientHandshake : public Handshake {
   folly::exception_wrapper error_;
 
   ActionMoveVisitor visitor_;
-  std::shared_ptr<const fizz::client::FizzClientContext> fizzClientContext_;
   folly::Optional<std::string> pskIdentity_;
 
   std::shared_ptr<ClientTransportParametersExtension> transportParams_;


### PR DESCRIPTION
It is not used anywhere.