### PR TITLE
Avoid use of the alias fizz::Buf and use std::unique_ptr<folly::IOBuf> instead.

### DIFF
--- a/quic/handshake/TransportParameters.cpp
+++ b/quic/handshake/TransportParameters.cpp
@@ -77,7 +77,7 @@ TransportParameter CustomStringTransportParameter::encode() const {
 
 CustomBlobTransportParameter::CustomBlobTransportParameter(
     uint16_t id,
-    fizz::Buf value)
+    std::unique_ptr<folly::IOBuf> value)
     : CustomTransportParameter(id), value_(std::move(value)) {}
 
 TransportParameter CustomBlobTransportParameter::encode() const {

--- a/quic/handshake/TransportParameters.h
+++ b/quic/handshake/TransportParameters.h
@@ -34,11 +34,11 @@ enum class TransportParameterId : uint16_t {
 
 struct TransportParameter {
   TransportParameterId parameter;
-  fizz::Buf value;
+  std::unique_ptr<folly::IOBuf> value;
 
   TransportParameter() {}
 
-  TransportParameter(TransportParameterId p, fizz::Buf v)
+  TransportParameter(TransportParameterId p, std::unique_ptr<folly::IOBuf> v)
       : parameter(p), value(v ? std::move(v) : nullptr) {}
 
   TransportParameter(const TransportParameter& other)
@@ -72,12 +72,14 @@ class CustomStringTransportParameter : public CustomTransportParameter {
 
 class CustomBlobTransportParameter : public CustomTransportParameter {
  public:
-  CustomBlobTransportParameter(uint16_t id, fizz::Buf value);
+  CustomBlobTransportParameter(
+      uint16_t id,
+      std::unique_ptr<folly::IOBuf> value);
 
   TransportParameter encode() const override;
 
  private:
-  fizz::Buf value_;
+  std::unique_ptr<folly::IOBuf> value_;
 };
 
 class CustomIntegralTransportParameter : public CustomTransportParameter {

--- a/quic/server/handshake/AppToken.cpp
+++ b/quic/server/handshake/AppToken.cpp
@@ -57,7 +57,7 @@ TicketTransportParameters createTicketTransportParameters(
   return params;
 }
 
-fizz::Buf encodeAppToken(const AppToken& appToken) {
+std::unique_ptr<folly::IOBuf> encodeAppToken(const AppToken& appToken) {
   auto buf = folly::IOBuf::create(20);
   folly::io::Appender appender(buf.get(), 20);
   auto ext = encodeExtension(appToken.transportParams);

--- a/quic/server/handshake/AppToken.h
+++ b/quic/server/handshake/AppToken.h
@@ -34,7 +34,7 @@ struct AppToken {
   TicketTransportParameters transportParams;
   std::vector<folly::IPAddress> sourceAddresses;
   folly::Optional<QuicVersion> version;
-  Buf appParams;
+  std::unique_ptr<folly::IOBuf> appParams;
 };
 
 TicketTransportParameters createTicketTransportParameters(
@@ -47,7 +47,7 @@ TicketTransportParameters createTicketTransportParameters(
     uint64_t initialMaxStreamsBidi,
     uint64_t initialMaxStreamsUni);
 
-fizz::Buf encodeAppToken(const AppToken& appToken);
+std::unique_ptr<folly::IOBuf> encodeAppToken(const AppToken& appToken);
 
 folly::Optional<AppToken> decodeAppToken(const folly::IOBuf& buf);
 


### PR DESCRIPTION
This allows to get rid of an unnecessary dependency on fizz. The values are generated using `folly::IOBuf::create` anyways, so it's not like it is adding a dependency that isn't there.