### PR TITLE
Remove ClientHandshake::getState()

### DIFF
--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -196,10 +196,6 @@ folly::Optional<bool> ClientHandshake::getZeroRttRejected() {
   return std::move(zeroRttRejected_);
 }
 
-const fizz::client::State& ClientHandshake::getState() const {
-  return state_;
-}
-
 const folly::Optional<std::string>& ClientHandshake::getApplicationProtocol()
     const {
   auto& earlyDataParams = state_.earlyDataParams();

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -142,11 +142,6 @@ class ClientHandshake : public Handshake {
   folly::Optional<bool> getZeroRttRejected();
 
   /**
-   * Returns the state of the TLS connection.
-   */
-  const fizz::client::State& getState() const;
-
-  /**
    * Returns the application protocol that was negotiated by the handshake.
    */
   const folly::Optional<std::string>& getApplicationProtocol() const override;


### PR DESCRIPTION
It is part of the public API and rely on fizz. Moreover, it is not used and therefore can be removed.