### PR TITLE
Move fizz specific ciphers in their own file

### DIFF
--- a/quic/codec/PacketNumberCipher.cpp
+++ b/quic/codec/PacketNumberCipher.cpp
@@ -13,8 +13,6 @@
 
 namespace quic {
 
-constexpr size_t kAES128KeyLength = 16;
-
 void PacketNumberCipher::decipherHeader(
     folly::ByteRange sample,
     folly::MutableByteRange initialByte,
@@ -96,64 +94,4 @@ void PacketNumberCipher::encryptShortHeader(
       ShortHeader::kPacketNumLenMask);
 }
 
-static void setKeyImpl(
-    folly::ssl::EvpCipherCtxUniquePtr& context,
-    const EVP_CIPHER* cipher,
-    folly::ByteRange key) {
-  DCHECK_EQ(key.size(), EVP_CIPHER_key_length(cipher));
-  context.reset(EVP_CIPHER_CTX_new());
-  if (context == nullptr) {
-    throw std::runtime_error("Unable to allocate an EVP_CIPHER_CTX object");
-  }
-  if (EVP_EncryptInit_ex(context.get(), cipher, nullptr, key.data(), nullptr) !=
-      1) {
-    throw std::runtime_error("Init error");
-  }
-}
-
-static HeaderProtectionMask maskImpl(
-    const folly::ssl::EvpCipherCtxUniquePtr& context,
-    folly::ByteRange sample) {
-  HeaderProtectionMask outMask;
-  CHECK_EQ(sample.size(), outMask.size());
-  int outLen = 0;
-  if (EVP_EncryptUpdate(
-          context.get(),
-          outMask.data(),
-          &outLen,
-          sample.data(),
-          sample.size()) != 1 ||
-      static_cast<HeaderProtectionMask::size_type>(outLen) != outMask.size()) {
-    throw std::runtime_error("Encryption error");
-  }
-  return outMask;
-}
-
-void Aes128PacketNumberCipher::setKey(folly::ByteRange key) {
-  return setKeyImpl(encryptCtx_, EVP_aes_128_ecb(), key);
-}
-
-void Aes256PacketNumberCipher::setKey(folly::ByteRange key) {
-  return setKeyImpl(encryptCtx_, EVP_aes_256_ecb(), key);
-}
-
-HeaderProtectionMask Aes128PacketNumberCipher::mask(
-    folly::ByteRange sample) const {
-  return maskImpl(encryptCtx_, sample);
-}
-
-HeaderProtectionMask Aes256PacketNumberCipher::mask(
-    folly::ByteRange sample) const {
-  return maskImpl(encryptCtx_, sample);
-}
-
-size_t Aes128PacketNumberCipher::keyLength() const {
-  return kAES128KeyLength;
-}
-
-constexpr size_t kAES256KeyLength = 32;
-
-size_t Aes256PacketNumberCipher::keyLength() const {
-  return kAES256KeyLength;
-}
 } // namespace quic

--- a/quic/codec/PacketNumberCipher.h
+++ b/quic/codec/PacketNumberCipher.h
@@ -10,7 +10,6 @@
 
 #include <folly/Optional.h>
 #include <folly/io/Cursor.h>
-#include <folly/ssl/OpenSSLPtrTypes.h>
 
 namespace quic {
 
@@ -88,31 +87,4 @@ class PacketNumberCipher {
       uint8_t packetNumLengthMask) const;
 };
 
-class Aes128PacketNumberCipher : public PacketNumberCipher {
- public:
-  ~Aes128PacketNumberCipher() override = default;
-
-  void setKey(folly::ByteRange key) override;
-
-  HeaderProtectionMask mask(folly::ByteRange sample) const override;
-
-  size_t keyLength() const override;
-
- private:
-  folly::ssl::EvpCipherCtxUniquePtr encryptCtx_;
-};
-
-class Aes256PacketNumberCipher : public PacketNumberCipher {
- public:
-  ~Aes256PacketNumberCipher() override = default;
-
-  void setKey(folly::ByteRange key) override;
-
-  HeaderProtectionMask mask(folly::ByteRange sample) const override;
-
-  size_t keyLength() const override;
-
- private:
-  folly::ssl::EvpCipherCtxUniquePtr encryptCtx_;
-};
 } // namespace quic

--- a/quic/codec/test/CMakeLists.txt
+++ b/quic/codec/test/CMakeLists.txt
@@ -58,14 +58,6 @@ quic_add_test(TARGET PacketNumberTest
   mvfst_codec_types
 )
 
-quic_add_test(TARGET PacketNumberCipherTest
-  SOURCES
-  PacketNumberCipherTest.cpp
-  DEPENDS
-  Folly::folly
-  mvfst_codec_packet_number_cipher
-)
-
 quic_add_test(TARGET DecodeTest
   SOURCES
   DecodeTest.cpp
@@ -103,7 +95,6 @@ quic_add_test(TARGET QuicPacketBuilderTest
   mvfst_state_stream_functions
   mvfst_test_utils
 )
-
 
 quic_add_test(TARGET QuicIntegerTest
   SOURCES

--- a/quic/handshake/CMakeLists.txt
+++ b/quic/handshake/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
   CryptoFactory.cpp
   FizzBridge.cpp
   FizzCryptoFactory.cpp
+  FizzPacketNumberCipher.cpp
   HandshakeLayer.cpp
   TransportParameters.cpp
 )

--- a/quic/handshake/FizzCryptoFactory.cpp
+++ b/quic/handshake/FizzCryptoFactory.cpp
@@ -9,6 +9,7 @@
 #include <quic/handshake/FizzCryptoFactory.h>
 
 #include <quic/handshake/FizzBridge.h>
+#include <quic/handshake/FizzPacketNumberCipher.h>
 #include <quic/handshake/HandshakeLayer.h>
 
 namespace {

--- a/quic/handshake/FizzPacketNumberCipher.cpp
+++ b/quic/handshake/FizzPacketNumberCipher.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#include <quic/handshake/FizzPacketNumberCipher.h>
+
+namespace quic {
+
+static void setKeyImpl(
+    folly::ssl::EvpCipherCtxUniquePtr& context,
+    const EVP_CIPHER* cipher,
+    folly::ByteRange key) {
+  DCHECK_EQ(key.size(), EVP_CIPHER_key_length(cipher));
+  context.reset(EVP_CIPHER_CTX_new());
+  if (context == nullptr) {
+    throw std::runtime_error("Unable to allocate an EVP_CIPHER_CTX object");
+  }
+  if (EVP_EncryptInit_ex(context.get(), cipher, nullptr, key.data(), nullptr) !=
+      1) {
+    throw std::runtime_error("Init error");
+  }
+}
+
+static HeaderProtectionMask maskImpl(
+    const folly::ssl::EvpCipherCtxUniquePtr& context,
+    folly::ByteRange sample) {
+  HeaderProtectionMask outMask;
+  CHECK_EQ(sample.size(), outMask.size());
+  int outLen = 0;
+  if (EVP_EncryptUpdate(
+          context.get(),
+          outMask.data(),
+          &outLen,
+          sample.data(),
+          sample.size()) != 1 ||
+      static_cast<HeaderProtectionMask::size_type>(outLen) != outMask.size()) {
+    throw std::runtime_error("Encryption error");
+  }
+  return outMask;
+}
+
+void Aes128PacketNumberCipher::setKey(folly::ByteRange key) {
+  return setKeyImpl(encryptCtx_, EVP_aes_128_ecb(), key);
+}
+
+void Aes256PacketNumberCipher::setKey(folly::ByteRange key) {
+  return setKeyImpl(encryptCtx_, EVP_aes_256_ecb(), key);
+}
+
+HeaderProtectionMask Aes128PacketNumberCipher::mask(
+    folly::ByteRange sample) const {
+  return maskImpl(encryptCtx_, sample);
+}
+
+HeaderProtectionMask Aes256PacketNumberCipher::mask(
+    folly::ByteRange sample) const {
+  return maskImpl(encryptCtx_, sample);
+}
+
+constexpr size_t kAES128KeyLength = 16;
+
+size_t Aes128PacketNumberCipher::keyLength() const {
+  return kAES128KeyLength;
+}
+
+constexpr size_t kAES256KeyLength = 32;
+
+size_t Aes256PacketNumberCipher::keyLength() const {
+  return kAES256KeyLength;
+}
+
+} // namespace quic

--- a/quic/handshake/FizzPacketNumberCipher.h
+++ b/quic/handshake/FizzPacketNumberCipher.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#pragma once
+
+#include <quic/codec/PacketNumberCipher.h>
+
+#include <folly/ssl/OpenSSLPtrTypes.h>
+
+namespace quic {
+
+class Aes128PacketNumberCipher : public PacketNumberCipher {
+ public:
+  ~Aes128PacketNumberCipher() override = default;
+
+  void setKey(folly::ByteRange key) override;
+
+  HeaderProtectionMask mask(folly::ByteRange sample) const override;
+
+  size_t keyLength() const override;
+
+ private:
+  folly::ssl::EvpCipherCtxUniquePtr encryptCtx_;
+};
+
+class Aes256PacketNumberCipher : public PacketNumberCipher {
+ public:
+  ~Aes256PacketNumberCipher() override = default;
+
+  void setKey(folly::ByteRange key) override;
+
+  HeaderProtectionMask mask(folly::ByteRange sample) const override;
+
+  size_t keyLength() const override;
+
+ private:
+  folly::ssl::EvpCipherCtxUniquePtr encryptCtx_;
+};
+
+} // namespace quic

--- a/quic/handshake/test/CMakeLists.txt
+++ b/quic/handshake/test/CMakeLists.txt
@@ -25,3 +25,12 @@ quic_add_test(TARGET FizzCryptoFactoryTest
   mvfst_handshake
   mvfst_test_utils
 )
+
+quic_add_test(TARGET FizzPacketNumberCipherTest
+  SOURCES
+  FizzPacketNumberCipherTest.cpp
+  DEPENDS
+  Folly::folly
+  mvfst_handshake
+  mvfst_codec_packet_number_cipher
+)

--- a/quic/handshake/test/FizzPacketNumberCipherTest.cpp
+++ b/quic/handshake/test/FizzPacketNumberCipherTest.cpp
@@ -9,7 +9,8 @@
 #include <folly/portability/GTest.h>
 
 #include <fizz/record/Types.h>
-#include <quic/codec/PacketNumberCipher.h>
+#include <quic/handshake/FizzCryptoFactory.h>
+#include <quic/handshake/FizzPacketNumberCipher.h>
 
 #include <folly/String.h>
 
@@ -17,20 +18,6 @@ using namespace testing;
 
 namespace quic {
 namespace test {
-
-// This is identical to code which will eventually live in
-// QuizFizzFactory
-std::unique_ptr<PacketNumberCipher> makePacketNumberCipher(
-    fizz::CipherSuite cipher) {
-  switch (cipher) {
-    case fizz::CipherSuite::TLS_AES_128_GCM_SHA256:
-      return std::make_unique<Aes128PacketNumberCipher>();
-    case fizz::CipherSuite::TLS_AES_256_GCM_SHA384:
-      return std::make_unique<Aes256PacketNumberCipher>();
-    default:
-      throw std::runtime_error("Packet number cipher not implemented");
-  }
-}
 
 struct HeaderParams {
   fizz::CipherSuite cipher;
@@ -75,7 +62,8 @@ struct CipherBytes {
 };
 
 TEST_P(LongPacketNumberCipherTest, TestEncryptDecrypt) {
-  auto cipher = makePacketNumberCipher(GetParam().cipher);
+  FizzCryptoFactory cryptoFactory;
+  auto cipher = cryptoFactory.makePacketNumberCipher(GetParam().cipher);
   auto key = folly::unhexlify(GetParam().key);
   EXPECT_EQ(cipher->keyLength(), key.size());
   cipher->setKey(folly::range(key));


### PR DESCRIPTION
Technically, there are not fizz specific but ssl specific. The goal being to package all of the ssl machinery together so it can be swapped in/out for something else.