### PR TITLE
Remove unused field pskIdentity_ from ClientHandshake

### DIFF
--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -197,8 +197,6 @@ class ClientHandshake : public Handshake {
 
   folly::exception_wrapper error_;
 
-  folly::Optional<std::string> pskIdentity_;
-
   std::shared_ptr<CryptoFactory> cryptoFactory_;
   std::shared_ptr<ClientTransportParametersExtension> transportParams_;
   bool earlyDataAttempted_{false};


### PR DESCRIPTION
As per title.