### PR TITLE
Remove needless fizz dependencies

### DIFF
--- a/quic/api/CMakeLists.txt
+++ b/quic/api/CMakeLists.txt
@@ -15,7 +15,6 @@ add_library(
 target_include_directories(
   mvfst_transport PUBLIC
   $<BUILD_INTERFACE:${QUIC_FBCODE_ROOT}>
-  $<BUILD_INTERFACE:${LIBFIZZ_INCLUDE_DIR}>
   $<INSTALL_INTERFACE:include/>
 )
 
@@ -50,7 +49,6 @@ add_dependencies(
 target_link_libraries(
   mvfst_transport PUBLIC
   Folly::folly
-  ${LIBFIZZ_LIBRARY}
   mvfst_cc_algo
   mvfst_codec
   mvfst_codec_pktbuilder

--- a/quic/congestion_control/CMakeLists.txt
+++ b/quic/congestion_control/CMakeLists.txt
@@ -20,7 +20,6 @@ add_library(
 target_include_directories(
   mvfst_cc_algo PUBLIC
   $<BUILD_INTERFACE:${QUIC_FBCODE_ROOT}>
-  $<BUILD_INTERFACE:${LIBFIZZ_INCLUDE_DIR}>
   $<INSTALL_INTERFACE:include/>
 )
 
@@ -41,7 +40,6 @@ add_dependencies(
 target_link_libraries(
   mvfst_cc_algo PUBLIC
   Folly::folly
-  ${LIBFIZZ_LIBRARY}
   mvfst_constants
   mvfst_exception
   mvfst_state_machine

--- a/quic/happyeyeballs/CMakeLists.txt
+++ b/quic/happyeyeballs/CMakeLists.txt
@@ -11,7 +11,6 @@ add_library(
 target_include_directories(
   mvfst_happyeyeballs PUBLIC
   $<BUILD_INTERFACE:${QUIC_FBCODE_ROOT}>
-  $<BUILD_INTERFACE:${LIBFIZZ_INCLUDE_DIR}>
   $<INSTALL_INTERFACE:include/>
 )
 
@@ -29,7 +28,6 @@ add_dependencies(
 target_link_libraries(
   mvfst_happyeyeballs PUBLIC
   Folly::folly
-  ${LIBFIZZ_LIBRARY}
   mvfst_state_machine
 )
 

--- a/quic/logging/CMakeLists.txt
+++ b/quic/logging/CMakeLists.txt
@@ -32,7 +32,6 @@ add_dependencies(
 target_link_libraries(
   mvfst_qlogger PUBLIC
   Folly::folly
-  ${LIBFIZZ_LIBRARY}
   mvfst_codec_types
 )
 


### PR DESCRIPTION
Several library are declared as depending on fizz when they actually do not.