### PR TITLE
Move the management of the certificate verifier and the fizz::client::FizzClientContext object to FizzClientContext

### DIFF
--- a/quic/api/test/IoBufQuicBatchTest.cpp
+++ b/quic/api/test/IoBufQuicBatchTest.cpp
@@ -56,7 +56,7 @@ void RunTest(int numBatch) {
   auto batchWriter = std::make_unique<TestPacketBatchWriter>(numBatch);
   folly::SocketAddress peerAddress{"127.0.0.1", 1234};
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   QuicConnectionStateBase::HappyEyeballsState happyEyeballsState;
 
   IOBufQuicBatch ioBufBatch(

--- a/quic/api/test/QuicPacketSchedulerTest.cpp
+++ b/quic/api/test/QuicPacketSchedulerTest.cpp
@@ -117,7 +117,7 @@ TEST_F(QuicPacketSchedulerTest, NoopScheduler) {
 
 TEST_F(QuicPacketSchedulerTest, CryptoPaddingInitialPacket) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   auto connId = getTestConnectionId();
   LongHeader longHeader1(
       LongHeader::Types::Initial,
@@ -177,7 +177,7 @@ TEST_F(QuicPacketSchedulerTest, CryptoServerInitialNotPadded) {
 
 TEST_F(QuicPacketSchedulerTest, CryptoPaddingRetransmissionClientInitial) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   auto connId = getTestConnectionId();
   LongHeader longHeader(
       LongHeader::Types::Initial,
@@ -225,7 +225,7 @@ TEST_F(QuicPacketSchedulerTest, CryptoSchedulerOnlySingleLossFits) {
 
 TEST_F(QuicPacketSchedulerTest, CryptoWritePartialLossBuffer) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   auto connId = getTestConnectionId();
   LongHeader longHeader(
       LongHeader::Types::Initial,
@@ -313,7 +313,7 @@ TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerStreamNotExists) {
 
 TEST_F(QuicPacketSchedulerTest, CloningSchedulerTest) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   FrameScheduler noopScheduler("frame");
   ASSERT_FALSE(noopScheduler.hasData());
   CloningScheduler cloningScheduler(noopScheduler, conn, "CopyCat", 0);
@@ -341,7 +341,7 @@ TEST_F(QuicPacketSchedulerTest, CloningSchedulerTest) {
 
 TEST_F(QuicPacketSchedulerTest, WriteOnlyOutstandingPacketsTest) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   FrameScheduler noopScheduler("frame");
   ASSERT_FALSE(noopScheduler.hasData());
   CloningScheduler cloningScheduler(noopScheduler, conn, "CopyCat", 0);
@@ -409,7 +409,7 @@ TEST_F(QuicPacketSchedulerTest, WriteOnlyOutstandingPacketsTest) {
 
 TEST_F(QuicPacketSchedulerTest, DoNotCloneProcessedClonedPacket) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   FrameScheduler noopScheduler("frame");
   CloningScheduler cloningScheduler(noopScheduler, conn, "CopyCat", 0);
   // Add two outstanding packets, but then mark the second one processed by
@@ -440,7 +440,7 @@ TEST_F(QuicPacketSchedulerTest, DoNotCloneProcessedClonedPacket) {
 
 TEST_F(QuicPacketSchedulerTest, DoNotClonePureAck) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   FrameScheduler noopScheduler("frame");
   CloningScheduler cloningScheduler(noopScheduler, conn, "CopyCat", 0);
   // Add two outstanding packets, with second one being pureAck
@@ -467,7 +467,7 @@ TEST_F(QuicPacketSchedulerTest, DoNotClonePureAck) {
 
 TEST_F(QuicPacketSchedulerTest, CloneSchedulerHasDataIgnoresNonAppData) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   FrameScheduler noopScheduler("frame");
   CloningScheduler cloningScheduler(noopScheduler, conn, "CopyCat", 0);
   EXPECT_FALSE(cloningScheduler.hasData());
@@ -484,7 +484,7 @@ TEST_F(QuicPacketSchedulerTest, CloneSchedulerHasDataIgnoresNonAppData) {
 
 TEST_F(QuicPacketSchedulerTest, DoNotCloneHandshake) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   FrameScheduler noopScheduler("frame");
   CloningScheduler cloningScheduler(noopScheduler, conn, "CopyCat", 0);
   // Add two outstanding packets, with second one being handshake
@@ -512,7 +512,7 @@ TEST_F(QuicPacketSchedulerTest, DoNotCloneHandshake) {
 
 TEST_F(QuicPacketSchedulerTest, CloneSchedulerUseNormalSchedulerFirst) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   MockFrameScheduler mockScheduler;
   CloningScheduler cloningScheduler(mockScheduler, conn, "Mocker", 0);
   ShortHeader header(
@@ -561,7 +561,7 @@ TEST_F(QuicPacketSchedulerTest, CloneSchedulerUseNormalSchedulerFirst) {
 
 TEST_F(QuicPacketSchedulerTest, CloneWillGenerateNewWindowUpdate) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
   FrameScheduler noopScheduler("frame");
@@ -643,7 +643,7 @@ class AckSchedulingTest : public TestWithParam<PacketNumberSpace> {};
 
 TEST_F(QuicPacketSchedulerTest, AckStateHasAcksToSchedule) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   EXPECT_FALSE(hasAcksToSchedule(conn.ackStates.initialAckState));
   EXPECT_FALSE(hasAcksToSchedule(conn.ackStates.handshakeAckState));
   EXPECT_FALSE(hasAcksToSchedule(conn.ackStates.appDataAckState));
@@ -661,7 +661,7 @@ TEST_F(QuicPacketSchedulerTest, AckStateHasAcksToSchedule) {
 
 TEST_F(QuicPacketSchedulerTest, AckSchedulerHasAcksToSchedule) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   AckScheduler initialAckScheduler(
       conn, getAckState(conn, PacketNumberSpace::Initial));
   AckScheduler handshakeAckScheduler(
@@ -685,7 +685,7 @@ TEST_F(QuicPacketSchedulerTest, AckSchedulerHasAcksToSchedule) {
 
 TEST_F(QuicPacketSchedulerTest, LargestAckToSend) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   EXPECT_EQ(folly::none, largestAckToSend(conn.ackStates.initialAckState));
   EXPECT_EQ(folly::none, largestAckToSend(conn.ackStates.handshakeAckState));
   EXPECT_EQ(folly::none, largestAckToSend(conn.ackStates.appDataAckState));
@@ -701,7 +701,7 @@ TEST_F(QuicPacketSchedulerTest, LargestAckToSend) {
 
 TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerAllFit) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   conn.flowControlState.peerAdvertisedMaxOffset = 100000;
   conn.flowControlState.peerAdvertisedInitialMaxStreamOffsetBidiRemote = 100000;
@@ -727,7 +727,7 @@ TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerAllFit) {
 
 TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerRoundRobin) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   conn.flowControlState.peerAdvertisedMaxOffset = 100000;
   conn.flowControlState.peerAdvertisedInitialMaxStreamOffsetBidiRemote = 100000;
@@ -781,7 +781,7 @@ TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerRoundRobin) {
 
 TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerRoundRobinControl) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   conn.flowControlState.peerAdvertisedMaxOffset = 100000;
   conn.flowControlState.peerAdvertisedInitialMaxStreamOffsetBidiRemote = 100000;
@@ -846,7 +846,7 @@ TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerRoundRobinControl) {
 
 TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerOneStream) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   conn.flowControlState.peerAdvertisedMaxOffset = 100000;
   conn.flowControlState.peerAdvertisedInitialMaxStreamOffsetBidiRemote = 100000;
@@ -868,7 +868,7 @@ TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerOneStream) {
 
 TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerRemoveOne) {
   QuicClientConnectionState conn(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   conn.flowControlState.peerAdvertisedMaxOffset = 100000;
   conn.flowControlState.peerAdvertisedInitialMaxStreamOffsetBidiRemote = 100000;

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -10,9 +10,7 @@
 
 #include <fizz/client/ClientProtocol.h>
 #include <fizz/client/EarlyDataRejectionPolicy.h>
-#include <fizz/client/FizzClientContext.h>
 #include <fizz/client/PskCache.h>
-#include <fizz/protocol/DefaultCertificateVerifier.h>
 
 #include <folly/io/IOBufQueue.h>
 #include <folly/io/async/DelayedDestruction.h>
@@ -45,8 +43,6 @@ class ClientHandshake : public Handshake {
    * Initiate the handshake with the supplied parameters.
    */
   virtual void connect(
-      std::shared_ptr<const fizz::client::FizzClientContext> context,
-      std::shared_ptr<const fizz::CertificateVerifier> verifier,
       folly::Optional<std::string> hostname,
       folly::Optional<fizz::client::CachedPsk> cachedPsk,
       const std::shared_ptr<ClientTransportParametersExtension>&

--- a/quic/client/handshake/FizzClientHandshake.h
+++ b/quic/client/handshake/FizzClientHandshake.h
@@ -21,8 +21,6 @@ class FizzClientHandshake : public ClientHandshake {
       std::shared_ptr<FizzClientQuicHandshakeContext> fizzContext);
 
   void connect(
-      std::shared_ptr<const fizz::client::FizzClientContext> context,
-      std::shared_ptr<const fizz::CertificateVerifier> verifier,
       folly::Optional<std::string> hostname,
       folly::Optional<fizz::client::CachedPsk> cachedPsk,
       const std::shared_ptr<ClientTransportParametersExtension>&

--- a/quic/client/handshake/FizzClientQuicHandshakeContext.cpp
+++ b/quic/client/handshake/FizzClientQuicHandshakeContext.cpp
@@ -12,10 +12,30 @@
 
 namespace quic {
 
+FizzClientQuicHandshakeContext::FizzClientQuicHandshakeContext(
+    std::shared_ptr<const fizz::client::FizzClientContext> context,
+    std::shared_ptr<const fizz::CertificateVerifier> verifier)
+    : context_(std::move(context)), verifier_(std::move(verifier)) {}
+
 std::unique_ptr<ClientHandshake>
 FizzClientQuicHandshakeContext::makeClientHandshake(
     QuicCryptoState& cryptoState) {
   return std::make_unique<FizzClientHandshake>(cryptoState, shared_from_this());
+}
+
+std::shared_ptr<FizzClientQuicHandshakeContext>
+FizzClientQuicHandshakeContext::Builder::build() {
+  if (!context_) {
+    context_ = std::make_shared<const fizz::client::FizzClientContext>();
+  }
+  if (!verifier_) {
+    verifier_ = std::make_shared<const fizz::DefaultCertificateVerifier>(
+        fizz::VerificationContext::Client);
+  }
+
+  return std::shared_ptr<FizzClientQuicHandshakeContext>(
+      new FizzClientQuicHandshakeContext(
+          std::move(context_), std::move(verifier_)));
 }
 
 } // namespace quic

--- a/quic/client/handshake/FizzClientQuicHandshakeContext.h
+++ b/quic/client/handshake/FizzClientQuicHandshakeContext.h
@@ -10,6 +10,9 @@
 
 #include <quic/client/handshake/ClientHandshakeFactory.h>
 
+#include <fizz/client/FizzClientContext.h>
+#include <fizz/protocol/DefaultCertificateVerifier.h>
+
 namespace quic {
 
 class FizzClientHandshake;
@@ -20,6 +23,54 @@ class FizzClientQuicHandshakeContext
  public:
   std::unique_ptr<ClientHandshake> makeClientHandshake(
       QuicCryptoState& cryptoState) override;
+
+  const std::shared_ptr<const fizz::client::FizzClientContext>& getContext()
+      const {
+    return context_;
+  }
+
+  const std::shared_ptr<const fizz::CertificateVerifier>&
+  getCertificateVerifier() const {
+    return verifier_;
+  }
+
+ private:
+  /**
+   * We make the constructor private so that users have to use the Builder
+   * facility. This ensures that
+   *   - This will ALWAYS be managed by a shared_ptr, which the implementation
+   * expects.
+   *   - We can enforce that the internal state of FizzClientContext is always
+   * sane.
+   */
+  FizzClientQuicHandshakeContext(
+      std::shared_ptr<const fizz::client::FizzClientContext> context,
+      std::shared_ptr<const fizz::CertificateVerifier> verifier);
+
+  std::shared_ptr<const fizz::client::FizzClientContext> context_;
+  std::shared_ptr<const fizz::CertificateVerifier> verifier_;
+
+ public:
+  class Builder {
+   public:
+    Builder& setFizzClientContext(
+        std::shared_ptr<const fizz::client::FizzClientContext> context) {
+      context_ = std::move(context);
+      return *this;
+    }
+
+    Builder& setCertificateVerifier(
+        std::shared_ptr<const fizz::CertificateVerifier> verifier) {
+      verifier_ = std::move(verifier);
+      return *this;
+    }
+
+    std::shared_ptr<FizzClientQuicHandshakeContext> build();
+
+   private:
+    std::shared_ptr<const fizz::client::FizzClientContext> context_;
+    std::shared_ptr<const fizz::CertificateVerifier> verifier_;
+  };
 };
 
 } // namespace quic

--- a/quic/client/handshake/test/ClientHandshakeTest.cpp
+++ b/quic/client/handshake/test/ClientHandshakeTest.cpp
@@ -56,8 +56,6 @@ class ClientHandshakeTest : public Test, public boost::static_visitor<> {
 
   virtual void connect() {
     handshake->connect(
-        clientCtx,
-        verifier,
         hostname,
         folly::none,
         std::make_shared<ClientTransportParametersExtension>(
@@ -81,10 +79,13 @@ class ClientHandshakeTest : public Test, public boost::static_visitor<> {
     // Fizz is the name of the identity for our server certificate.
     hostname = "Fizz";
     setupClientAndServerContext();
+
     verifier = std::make_shared<fizz::test::MockCertificateVerifier>();
-    handshake =
-        std::make_shared<FizzClientQuicHandshakeContext>()->makeClientHandshake(
-            cryptoState);
+    handshake = FizzClientQuicHandshakeContext::Builder()
+                    .setFizzClientContext(clientCtx)
+                    .setCertificateVerifier(verifier)
+                    .build()
+                    ->makeClientHandshake(cryptoState);
     std::vector<QuicVersion> supportedVersions = {getVersion()};
     auto serverTransportParameters =
         std::make_shared<ServerTransportParametersExtension>(
@@ -348,8 +349,6 @@ class ClientHandshakeCallbackTest : public ClientHandshakeTest {
 
   void connect() override {
     handshake->connect(
-        clientCtx,
-        verifier,
         hostname,
         folly::none,
         std::make_shared<ClientTransportParametersExtension>(
@@ -450,8 +449,6 @@ class ClientHandshakeZeroRttTest : public ClientHandshakeTest {
 
   void connect() override {
     handshake->connect(
-        clientCtx,
-        verifier,
         hostname,
         psk.cachedPsk,
         std::make_shared<ClientTransportParametersExtension>(

--- a/quic/loss/test/QuicLossFunctionsTest.cpp
+++ b/quic/loss/test/QuicLossFunctionsTest.cpp
@@ -87,7 +87,7 @@ class QuicLossFunctionsTest : public TestWithParam<PacketNumberSpace> {
 
   std::unique_ptr<QuicClientConnectionState> createClientConn() {
     auto conn = std::make_unique<QuicClientConnectionState>(
-        std::make_shared<FizzClientQuicHandshakeContext>());
+        FizzClientQuicHandshakeContext::Builder().build());
     conn->clientConnectionId = getTestConnectionId();
     conn->version = QuicVersion::MVFST;
     conn->ackStates.initialAckState.nextPacketNum = 1;

--- a/quic/state/test/QuicStreamFunctionsTest.cpp
+++ b/quic/state/test/QuicStreamFunctionsTest.cpp
@@ -29,7 +29,7 @@ using PeekIterator = std::deque<StreamBuffer>::const_iterator;
 class QuicStreamFunctionsTest : public Test {
  public:
   QuicStreamFunctionsTest()
-      : conn(std::make_shared<FizzClientQuicHandshakeContext>()) {}
+      : conn(FizzClientQuicHandshakeContext::Builder().build()) {}
 
   void SetUp() override {
     conn.flowControlState.peerAdvertisedInitialMaxStreamOffsetBidiLocal =
@@ -1088,7 +1088,7 @@ TEST_F(QuicStreamFunctionsTest, IsBidirectionalStream) {
 
 TEST_F(QuicStreamFunctionsTest, IsSendingStream) {
   QuicClientConnectionState clientState(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   QuicServerConnectionState serverState;
   QuicNodeType nodeType;
   StreamId id;
@@ -1116,7 +1116,7 @@ TEST_F(QuicStreamFunctionsTest, IsSendingStream) {
 
 TEST_F(QuicStreamFunctionsTest, IsReceivingStream) {
   QuicClientConnectionState clientState(
-      std::make_shared<FizzClientQuicHandshakeContext>());
+      FizzClientQuicHandshakeContext::Builder().build());
   QuicServerConnectionState serverState;
   QuicNodeType nodeType;
   StreamId id;

--- a/quic/tools/tperf/tperf.cpp
+++ b/quic/tools/tperf/tperf.cpp
@@ -15,6 +15,7 @@
 #include <folly/stats/Histogram.h>
 
 #include <quic/client/QuicClientTransport.h>
+#include <quic/client/handshake/FizzClientQuicHandshakeContext.h>
 #include <quic/common/test/TestUtils.h>
 #include <quic/congestion_control/CongestionControllerFactory.h>
 #include <quic/server/QuicServer.h>
@@ -433,10 +434,13 @@ class TPerfClient : public quic::QuicSocket::ConnectionCallback,
     folly::SocketAddress addr(host_.c_str(), port_);
 
     auto sock = std::make_unique<folly::AsyncUDPSocket>(&eventBase_);
+    auto fizzClientContext =
+        FizzClientQuicHandshakeContext::Builder()
+            .setCertificateVerifier(test::createTestCertificateVerifier())
+            .build();
     quicClient_ = std::make_shared<quic::QuicClientTransport>(
-        &eventBase_, std::move(sock));
+        &eventBase_, std::move(sock), std::move(fizzClientContext));
     quicClient_->setHostname("tperf");
-    quicClient_->setCertificateVerifier(test::createTestCertificateVerifier());
     quicClient_->addNewPeerAddress(addr);
     quicClient_->setCongestionControllerFactory(
         std::make_shared<DefaultCongestionControllerFactory>());


### PR DESCRIPTION
This allows to remove various fizz specific parts of the API.