### PR TITLE
Move all use of fizz::client::ClientStateMachine into FizzClientHandshake

### DIFF
--- a/quic/client/handshake/FizzClientHandshake.h
+++ b/quic/client/handshake/FizzClientHandshake.h
@@ -28,6 +28,13 @@ class FizzClientHandshake : public ClientHandshake {
       HandshakeCallback* callback) override;
 
  private:
+  void processSocketData(folly::IOBufQueue& queue) override;
+
+  class ActionMoveVisitor;
+  void processActions(fizz::client::Actions actions);
+
+  fizz::client::ClientStateMachine machine_;
+
   std::shared_ptr<FizzClientQuicHandshakeContext> fizzContext_;
 };
 

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -1261,6 +1261,11 @@ class FakeOneRttHandshakeLayer : public ClientHandshake {
   uint64_t maxInitialStreamsBidi{std::numeric_limits<uint32_t>::max()};
   uint64_t maxInitialStreamsUni{std::numeric_limits<uint32_t>::max()};
   folly::Optional<ServerTransportParameters> params_;
+
+  // Implement virtual methods we don't intend to use.
+  void processSocketData(folly::IOBufQueue&) override {
+    throw std::runtime_error("processSocketData not implemented");
+  }
 };
 
 class QuicClientTransportTest : public Test {


### PR DESCRIPTION
Starting to migrate fizz specific features to the fizz specific handshake class.