### PR TITLE
Add libfmt-dev as a dependency

### DIFF
--- a/build_helper.sh
+++ b/build_helper.sh
@@ -99,6 +99,7 @@ function install_dependencies_linux() {
     libboost-all-dev          \
     libevent-dev              \
     libdouble-conversion-dev  \
+    libfmt-dev                \
     libgoogle-glog-dev        \
     libgflags-dev             \
     libiberty-dev             \


### PR DESCRIPTION
Looks like it is required.