### PR TITLE
Move cipher computation down to FizzClientHandshake

### DIFF
--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -20,7 +20,6 @@
 #include <quic/QuicException.h>
 #include <quic/client/handshake/ClientTransportParametersExtension.h>
 #include <quic/client/handshake/QuicPskCache.h>
-#include <quic/handshake/CryptoFactory.h>
 #include <quic/handshake/HandshakeLayer.h>
 #include <quic/state/StateData.h>
 
@@ -193,7 +192,8 @@ class ClientHandshake : public Handshake {
  private:
   EncryptionLevel getReadRecordLayerEncryptionLevel();
   virtual void processSocketData(folly::IOBufQueue& queue) = 0;
-  std::unique_ptr<Aead> buildAead(CipherKind kind, folly::ByteRange secret);
+  virtual std::pair<std::unique_ptr<Aead>, std::unique_ptr<PacketNumberCipher>>
+  buildCiphers(CipherKind kind, folly::ByteRange secret) = 0;
 
   // Whether or not to wait for more data.
   bool waitForData_{false};
@@ -209,7 +209,6 @@ class ClientHandshake : public Handshake {
  protected:
   fizz::client::State state_;
 
-  std::shared_ptr<CryptoFactory> cryptoFactory_;
   std::shared_ptr<ClientTransportParametersExtension> transportParams_;
 };
 

--- a/quic/client/handshake/FizzClientHandshake.h
+++ b/quic/client/handshake/FizzClientHandshake.h
@@ -13,6 +13,7 @@
 namespace quic {
 
 class FizzClientQuicHandshakeContext;
+class FizzCryptoFactory;
 
 class FizzClientHandshake : public ClientHandshake {
  public:
@@ -29,6 +30,8 @@ class FizzClientHandshake : public ClientHandshake {
 
  private:
   void processSocketData(folly::IOBufQueue& queue) override;
+  std::pair<std::unique_ptr<Aead>, std::unique_ptr<PacketNumberCipher>>
+  buildCiphers(CipherKind kind, folly::ByteRange secret) override;
 
   class ActionMoveVisitor;
   void processActions(fizz::client::Actions actions);
@@ -36,6 +39,7 @@ class FizzClientHandshake : public ClientHandshake {
   fizz::client::ClientStateMachine machine_;
 
   std::shared_ptr<FizzClientQuicHandshakeContext> fizzContext_;
+  std::shared_ptr<FizzCryptoFactory> cryptoFactory_;
 };
 
 } // namespace quic

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -1261,6 +1261,10 @@ class FakeOneRttHandshakeLayer : public ClientHandshake {
   void processSocketData(folly::IOBufQueue&) override {
     throw std::runtime_error("processSocketData not implemented");
   }
+  std::pair<std::unique_ptr<Aead>, std::unique_ptr<PacketNumberCipher>>
+  buildCiphers(CipherKind, folly::ByteRange) override {
+    throw std::runtime_error("buildCiphers not implemented");
+  }
 };
 
 class QuicClientTransportTest : public Test {


### PR DESCRIPTION
This helps moving more fizz specific feature to FizzClientHandshake.

Depends on #65 .