### PR TITLE
Remove explicit use of FizzCryptoFactory from QuicClientTransport

### DIFF
--- a/quic/client/QuicClientTransport.cpp
+++ b/quic/client/QuicClientTransport.cpp
@@ -15,7 +15,7 @@
 #include <quic/client/handshake/ClientTransportParametersExtension.h>
 #include <quic/client/state/ClientStateMachine.h>
 #include <quic/flowcontrol/QuicFlowController.h>
-#include <quic/handshake/FizzCryptoFactory.h>
+#include <quic/handshake/CryptoFactory.h>
 #include <quic/happyeyeballs/QuicHappyEyeballsFunctions.h>
 #include <quic/logging/QLoggerConstants.h>
 #include <quic/loss/QuicLossFunctions.h>
@@ -863,7 +863,9 @@ void QuicClientTransport::startCryptoHandshake() {
     cachedPsk = std::move(quicCachedPsk->cachedPsk);
   }
 
-  FizzCryptoFactory cryptoFactory;
+  auto handshakeLayer = clientConn_->clientHandshakeLayer;
+  auto& cryptoFactory = handshakeLayer->getCryptoFactory();
+
   auto version = conn_->originalVersion.value();
   conn_->initialWriteCipher = cryptoFactory.getClientInitialCipher(
       *clientConn_->initialDestinationConnectionId, version);
@@ -890,7 +892,6 @@ void QuicClientTransport::startCryptoHandshake() {
       conn_->transportSettings.selfActiveConnectionIdLimit,
       customTransportParameters_);
   conn_->transportParametersEncoded = true;
-  auto handshakeLayer = clientConn_->clientHandshakeLayer;
   handshakeLayer->connect(
       hostname_, std::move(cachedPsk), std::move(paramsExtension), this);
 

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -25,6 +25,8 @@
 
 namespace quic {
 
+class CryptoFactory;
+
 class ClientHandshake : public Handshake {
  public:
   class HandshakeCallback {
@@ -116,6 +118,11 @@ class ClientHandshake : public Handshake {
    * receive the header cipher subsequent calls will return null.
    */
   std::unique_ptr<PacketNumberCipher> getZeroRttWriteHeaderCipher();
+
+  /**
+   * Returns a reference to the CryptoFactory used internaly.
+   */
+  virtual const CryptoFactory& getCryptoFactory() const = 0;
 
   /**
    * Notify the crypto layer that we received one rtt protected data.

--- a/quic/client/handshake/FizzClientHandshake.cpp
+++ b/quic/client/handshake/FizzClientHandshake.cpp
@@ -46,6 +46,10 @@ void FizzClientHandshake::connect(
       transportParams));
 }
 
+const CryptoFactory& FizzClientHandshake::getCryptoFactory() const {
+  return cryptoFactory_;
+}
+
 void FizzClientHandshake::processSocketData(folly::IOBufQueue& queue) {
   processActions(machine_.processSocketData(state_, queue));
 }

--- a/quic/client/handshake/FizzClientHandshake.h
+++ b/quic/client/handshake/FizzClientHandshake.h
@@ -28,6 +28,8 @@ class FizzClientHandshake : public ClientHandshake {
           transportParams,
       HandshakeCallback* callback) override;
 
+  const CryptoFactory& getCryptoFactory() const override;
+
  private:
   void processSocketData(folly::IOBufQueue& queue) override;
   std::pair<std::unique_ptr<Aead>, std::unique_ptr<PacketNumberCipher>>

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -1257,6 +1257,11 @@ class FakeOneRttHandshakeLayer : public ClientHandshake {
   uint64_t maxInitialStreamsUni{std::numeric_limits<uint32_t>::max()};
   folly::Optional<ServerTransportParameters> params_;
 
+  FizzCryptoFactory cryptoFactory_;
+  const CryptoFactory& getCryptoFactory() const override {
+    return cryptoFactory_;
+  }
+
   // Implement virtual methods we don't intend to use.
   void processSocketData(folly::IOBufQueue&) override {
     throw std::runtime_error("processSocketData not implemented");


### PR DESCRIPTION
One less use of Fizz in "shared" space.

Depends on #70 