### PR TITLE
clang-tidy | Disable 'modernize-use-trailing-return-type' check for all users

### DIFF
--- a/quic/.clang-tidy
+++ b/quic/.clang-tidy
@@ -1,3 +1,3 @@
 ---
-Checks:          'boost-*,bugprone-*,clang-analyzer-*,modernize-*,performance-*'
+Checks:          'boost-*,bugprone-*,clang-analyzer-*,modernize-*,performance-*,-modernize-use-trailing-return-type'
 ...


### PR DESCRIPTION
Summary:
This is a very weird check from Clang 9. It doesn't conform to Facebook's C++ style guide and it's better to disable it.

## Code style enforced by this check

```
auto getSomeValue() -> std::vector<int> {
  // implementation
}
```

## Code style used at Facebook

```
std::vector<int> getSomeValue() {
  // implementation
}
```

Reviewed By: vybv

Differential Revision: D19159146

