### PR TITLE
Remove various unecessary inclusion of fizz headersin the client code.

### DIFF
--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -8,7 +8,6 @@
 
 #include <quic/client/handshake/ClientHandshake.h>
 
-#include <quic/fizz/handshake/FizzBridge.h>
 #include <quic/state/QuicStreamFunctions.h>
 
 namespace quic {

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -9,8 +9,6 @@
 #pragma once
 
 #include <fizz/client/ClientProtocol.h>
-#include <fizz/client/EarlyDataRejectionPolicy.h>
-#include <fizz/client/PskCache.h>
 
 #include <folly/io/IOBufQueue.h>
 #include <folly/io/async/DelayedDestruction.h>

--- a/quic/client/handshake/ClientTransportParametersExtension.h
+++ b/quic/client/handshake/ClientTransportParametersExtension.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <quic/fizz/handshake/FizzTransportParameters.h>
+#include <quic/handshake/TransportParameters.h>
 
 namespace quic {
 

--- a/quic/client/handshake/FizzClientHandshake.cpp
+++ b/quic/client/handshake/FizzClientHandshake.cpp
@@ -12,6 +12,7 @@
 #include <quic/client/handshake/FizzClientQuicHandshakeContext.h>
 #include <quic/fizz/handshake/FizzBridge.h>
 
+#include <fizz/client/EarlyDataRejectionPolicy.h>
 #include <fizz/protocol/Protocol.h>
 
 namespace quic {


### PR DESCRIPTION
The reduce unnecessary exposure of common code to fizz and hopefully gets us one step closer to complete separation.