### PR TITLE
Extract CachedServerTransportParameters in its own file

### DIFF
--- a/quic/client/handshake/CachedServerTransportParameters.h
+++ b/quic/client/handshake/CachedServerTransportParameters.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#pragma once
+
+#include <quic/QuicConstants.h>
+
+#include <cstdint>
+
+namespace quic {
+
+struct CachedServerTransportParameters {
+  QuicVersion negotiatedVersion;
+  uint64_t idleTimeout;
+  uint64_t maxRecvPacketSize;
+  uint64_t initialMaxData;
+  uint64_t initialMaxStreamDataBidiLocal;
+  uint64_t initialMaxStreamDataBidiRemote;
+  uint64_t initialMaxStreamDataUni;
+  uint64_t initialMaxStreamsBidi;
+  uint64_t initialMaxStreamsUni;
+};
+
+} // namespace quic

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -19,7 +19,6 @@
 #include <quic/QuicConstants.h>
 #include <quic/QuicException.h>
 #include <quic/client/handshake/ClientTransportParametersExtension.h>
-#include <quic/client/handshake/QuicPskCache.h>
 #include <quic/handshake/HandshakeLayer.h>
 #include <quic/state/StateData.h>
 

--- a/quic/client/handshake/QuicPskCache.h
+++ b/quic/client/handshake/QuicPskCache.h
@@ -8,27 +8,14 @@
 
 #pragma once
 
-#include <quic/QuicConstants.h>
+#include <quic/client/handshake/CachedServerTransportParameters.h>
 
 #include <fizz/client/PskCache.h>
 #include <folly/Optional.h>
 
-#include <cstdint>
 #include <string>
 
 namespace quic {
-
-struct CachedServerTransportParameters {
-  QuicVersion negotiatedVersion;
-  uint64_t idleTimeout;
-  uint64_t maxRecvPacketSize;
-  uint64_t initialMaxData;
-  uint64_t initialMaxStreamDataBidiLocal;
-  uint64_t initialMaxStreamDataBidiRemote;
-  uint64_t initialMaxStreamDataUni;
-  uint64_t initialMaxStreamsBidi;
-  uint64_t initialMaxStreamsUni;
-};
 
 struct QuicCachedPsk {
   fizz::client::CachedPsk cachedPsk;

--- a/quic/client/state/ClientStateMachine.cpp
+++ b/quic/client/state/ClientStateMachine.cpp
@@ -9,7 +9,6 @@
 #include <quic/client/state/ClientStateMachine.h>
 
 #include <folly/io/async/AsyncSocketException.h>
-#include <quic/client/handshake/ClientHandshake.h>
 #include <quic/congestion_control/QuicCubic.h>
 #include <quic/flowcontrol/QuicFlowController.h>
 #include <quic/handshake/TransportParameters.h>

--- a/quic/client/state/ClientStateMachine.h
+++ b/quic/client/state/ClientStateMachine.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <folly/io/async/AsyncSocketException.h>
+#include <quic/client/handshake/CachedServerTransportParameters.h>
 #include <quic/client/handshake/ClientHandshake.h>
 #include <quic/client/handshake/ClientHandshakeFactory.h>
 #include <quic/congestion_control/QuicCubic.h>


### PR DESCRIPTION
QuicCachedPsk depends on fizz, CachedServerTransportParameters doesn't, so this is one step further toward separating fizz specific part of the code from the rest.