### PR TITLE
Remove folly::Optionnal wrapper around actionGuard_

### DIFF
--- a/quic/server/handshake/ServerHandshake.cpp
+++ b/quic/server/handshake/ServerHandshake.cpp
@@ -15,7 +15,7 @@
 
 namespace quic {
 ServerHandshake::ServerHandshake(QuicCryptoState& cryptoState)
-    : cryptoState_(cryptoState), visitor_(*this) {}
+    : actionGuard_(nullptr), cryptoState_(cryptoState), visitor_(*this) {}
 
 void ServerHandshake::accept(
     std::shared_ptr<ServerTransportParametersExtension> transportParams) {
@@ -294,7 +294,7 @@ void ServerHandshake::processActions(
     }
   }
 
-  actionGuard_.clear();
+  actionGuard_ = folly::DelayedDestruction::DestructorGuard(nullptr);
   if (callback_ && !inHandshakeStack_ && handshakeEventAvailable_) {
     callback_->onCryptoEventAvailable();
   }
@@ -339,7 +339,7 @@ void ServerHandshake::processPendingEvents() {
       actions.emplace(
           machine_.processWriteNewSessionTicket(state_, std::move(write)));
     } else {
-      actionGuard_.clear();
+      actionGuard_ = folly::DelayedDestruction::DestructorGuard(nullptr);
       return;
     }
     startActions(std::move(*actions));

--- a/quic/server/handshake/ServerHandshake.h
+++ b/quic/server/handshake/ServerHandshake.h
@@ -247,7 +247,7 @@ class ServerHandshake : public Handshake {
 
   fizz::server::State state_;
   fizz::server::ServerStateMachine machine_;
-  folly::Optional<folly::DelayedDestruction::DestructorGuard> actionGuard_;
+  folly::DelayedDestruction::DestructorGuard actionGuard_;
   folly::Executor* executor_;
   std::shared_ptr<const fizz::server::FizzServerContext> context_;
   using PendingEvent = fizz::WriteNewSessionTicket;


### PR DESCRIPTION
It is purely redudant as DestructorGuard itself supports being "empty", casts to bool and everything.