### PR TITLE
Only take a QuicServerConnectionState when constructing ServerHandshake

### DIFF
--- a/quic/server/handshake/ServerHandshake.cpp
+++ b/quic/server/handshake/ServerHandshake.cpp
@@ -15,12 +15,10 @@
 #include <fizz/protocol/Protocol.h>
 
 namespace quic {
-ServerHandshake::ServerHandshake(
-    QuicConnectionStateBase* conn,
-    QuicCryptoState& cryptoState)
+ServerHandshake::ServerHandshake(QuicConnectionStateBase* conn)
     : conn_(conn),
       actionGuard_(nullptr),
-      cryptoState_(cryptoState),
+      cryptoState_(*conn->cryptoState),
       visitor_(*this) {}
 
 void ServerHandshake::accept(

--- a/quic/server/handshake/ServerHandshake.h
+++ b/quic/server/handshake/ServerHandshake.h
@@ -71,9 +71,7 @@ class ServerHandshake : public Handshake {
    */
   enum class Phase { Handshake, KeysDerived, Established };
 
-  explicit ServerHandshake(
-      QuicConnectionStateBase* conn,
-      QuicCryptoState& cryptoState);
+  explicit ServerHandshake(QuicConnectionStateBase* conn);
 
   /**
    * Starts accepting the TLS connection.

--- a/quic/server/state/ServerStateMachine.h
+++ b/quic/server/state/ServerStateMachine.h
@@ -133,7 +133,7 @@ struct QuicServerConnectionState : public QuicConnectionStateBase {
                                                   QuicVersion::QUIC_DRAFT,
                                                   QuicVersion::QUIC_DRAFT_23}};
     originalVersion = QuicVersion::MVFST;
-    serverHandshakeLayer = new ServerHandshake(this, *cryptoState);
+    serverHandshakeLayer = new ServerHandshake(this);
     handshakeLayer.reset(serverHandshakeLayer);
     // We shouldn't normally need to set this until we're starting the
     // transport, however writing unit tests is much easier if we set this here.

--- a/quic/server/test/QuicServerTransportTest.cpp
+++ b/quic/server/test/QuicServerTransportTest.cpp
@@ -44,7 +44,7 @@ class FakeServerHandshake : public ServerHandshake {
       bool chloSync = false,
       bool cfinSync = false,
       folly::Optional<uint64_t> clientActiveConnectionIdLimit = folly::none)
-      : ServerHandshake(&conn, *conn.cryptoState),
+      : ServerHandshake(&conn),
         conn_(conn),
         chloSync_(chloSync),
         cfinSync_(cfinSync),


### PR DESCRIPTION
The cryptoState can be derrived from it, so it is redundant to pass it.

This PR depends on #88 