### PR TITLE
Pass QuicClientConnectionState down to ClientHandshake

### DIFF
--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -8,12 +8,13 @@
 
 #include <quic/client/handshake/ClientHandshake.h>
 
+#include <quic/client/state/ClientStateMachine.h>
 #include <quic/state/QuicStreamFunctions.h>
 
 namespace quic {
 
-ClientHandshake::ClientHandshake(QuicCryptoState& cryptoState)
-    : cryptoState_(cryptoState) {}
+ClientHandshake::ClientHandshake(QuicClientConnectionState* conn)
+    : conn_(conn) {}
 
 void ClientHandshake::doHandshake(
     std::unique_ptr<folly::IOBuf> data,
@@ -194,7 +195,7 @@ void ClientHandshake::writeDataToStream(
     // Don't write 1-rtt handshake data on the client.
     return;
   }
-  auto cryptoStream = getCryptoStream(cryptoState_, encryptionLevel);
+  auto cryptoStream = getCryptoStream(*conn_->cryptoState, encryptionLevel);
   writeDataToQuicStream(*cryptoStream, std::move(data));
 }
 

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -12,17 +12,18 @@
 
 #include <folly/io/IOBufQueue.h>
 #include <folly/io/async/DelayedDestruction.h>
-
 #include <folly/ExceptionWrapper.h>
+
 #include <quic/QuicConstants.h>
 #include <quic/QuicException.h>
 #include <quic/client/handshake/ClientTransportParametersExtension.h>
+#include <quic/handshake/Aead.h>
 #include <quic/handshake/HandshakeLayer.h>
-#include <quic/state/StateData.h>
 
 namespace quic {
 
 class CryptoFactory;
+struct QuicClientConnectionState;
 
 class ClientHandshake : public Handshake {
  public:
@@ -35,7 +36,7 @@ class ClientHandshake : public Handshake {
 
   enum class Phase { Initial, Handshake, OneRttKeysDerived, Established };
 
-  explicit ClientHandshake(QuicCryptoState& cryptoState);
+  explicit ClientHandshake(QuicClientConnectionState* conn);
 
   /**
    * Initiate the handshake with the supplied parameters.
@@ -176,7 +177,7 @@ class ClientHandshake : public Handshake {
 
   folly::Optional<bool> zeroRttRejected_;
   HandshakeCallback* callback_{nullptr};
-  QuicCryptoState& cryptoState_;
+  QuicClientConnectionState* conn_;
 
   /**
    * Various utilities for concrete implementations to use.

--- a/quic/client/handshake/ClientHandshakeFactory.h
+++ b/quic/client/handshake/ClientHandshakeFactory.h
@@ -13,7 +13,7 @@
 namespace quic {
 
 class ClientHandshake;
-struct QuicCryptoState;
+struct QuicClientConnectionState;
 
 class ClientHandshakeFactory {
  public:
@@ -26,7 +26,7 @@ class ClientHandshakeFactory {
    * of the ClientHandshake.
    */
   virtual std::unique_ptr<ClientHandshake> makeClientHandshake(
-      QuicCryptoState& cryptoState) = 0;
+      QuicClientConnectionState* conn) = 0;
 };
 
 } // namespace quic

--- a/quic/client/handshake/FizzClientHandshake.cpp
+++ b/quic/client/handshake/FizzClientHandshake.cpp
@@ -18,9 +18,9 @@
 namespace quic {
 
 FizzClientHandshake::FizzClientHandshake(
-    QuicCryptoState& cryptoState,
+    QuicClientConnectionState* conn,
     std::shared_ptr<FizzClientQuicHandshakeContext> fizzContext)
-    : ClientHandshake(cryptoState), fizzContext_(std::move(fizzContext)) {}
+    : ClientHandshake(conn), fizzContext_(std::move(fizzContext)) {}
 
 void FizzClientHandshake::connect(
     folly::Optional<std::string> hostname,

--- a/quic/client/handshake/FizzClientHandshake.h
+++ b/quic/client/handshake/FizzClientHandshake.h
@@ -14,11 +14,12 @@
 namespace quic {
 
 class FizzClientQuicHandshakeContext;
+struct QuicClientConnectionState;
 
 class FizzClientHandshake : public ClientHandshake {
  public:
   FizzClientHandshake(
-      QuicCryptoState& cryptoState,
+      QuicClientConnectionState* conn,
       std::shared_ptr<FizzClientQuicHandshakeContext> fizzContext);
 
   void connect(

--- a/quic/client/handshake/FizzClientQuicHandshakeContext.cpp
+++ b/quic/client/handshake/FizzClientQuicHandshakeContext.cpp
@@ -19,8 +19,8 @@ FizzClientQuicHandshakeContext::FizzClientQuicHandshakeContext(
 
 std::unique_ptr<ClientHandshake>
 FizzClientQuicHandshakeContext::makeClientHandshake(
-    QuicCryptoState& cryptoState) {
-  return std::make_unique<FizzClientHandshake>(cryptoState, shared_from_this());
+    QuicClientConnectionState* conn) {
+  return std::make_unique<FizzClientHandshake>(conn, shared_from_this());
 }
 
 std::shared_ptr<FizzClientQuicHandshakeContext>

--- a/quic/client/handshake/FizzClientQuicHandshakeContext.h
+++ b/quic/client/handshake/FizzClientQuicHandshakeContext.h
@@ -22,7 +22,7 @@ class FizzClientQuicHandshakeContext
       public std::enable_shared_from_this<FizzClientQuicHandshakeContext> {
  public:
   std::unique_ptr<ClientHandshake> makeClientHandshake(
-      QuicCryptoState& cryptoState) override;
+      QuicClientConnectionState* conn) override;
 
   const std::shared_ptr<const fizz::client::FizzClientContext>& getContext()
       const {

--- a/quic/client/state/ClientStateMachine.h
+++ b/quic/client/state/ClientStateMachine.h
@@ -57,8 +57,7 @@ struct QuicClientConnectionState : public QuicConnectionStateBase {
     connectionTime = Clock::now();
     originalVersion = QuicVersion::MVFST;
     DCHECK(handshakeFactory);
-    auto tmpClientHandshake =
-        handshakeFactory->makeClientHandshake(*cryptoState);
+    auto tmpClientHandshake = handshakeFactory->makeClientHandshake(this);
     clientHandshakeLayer = tmpClientHandshake.get();
     handshakeLayer = std::move(tmpClientHandshake);
     // We shouldn't normally need to set this until we're starting the


### PR DESCRIPTION
This is similar to #88 except that in this case, QuicClientConnectionState is actually needed to move forward.