### PR TITLE
Move 0RTT cipher management to the handshake.

### DIFF
--- a/quic/client/QuicClientTransport.cpp
+++ b/quic/client/QuicClientTransport.cpp
@@ -893,15 +893,11 @@ void QuicClientTransport::startCryptoHandshake() {
   handshakeLayer->connect(
       hostname_, std::move(cachedPsk), std::move(paramsExtension), this);
 
-  auto zeroRttWriteCipher = handshakeLayer->getZeroRttWriteCipher();
-  auto zeroRttWriteHeaderCipher = handshakeLayer->getZeroRttWriteHeaderCipher();
-  if (zeroRttWriteCipher) {
+  if (clientConn_->zeroRttWriteCipher) {
     if (conn_->qLogger) {
       conn_->qLogger->addTransportStateUpdate(kZeroRttAttempted);
     }
     QUIC_TRACE(zero_rtt, *conn_, "attempted");
-    clientConn_->zeroRttWriteCipher = std::move(zeroRttWriteCipher);
-    clientConn_->zeroRttWriteHeaderCipher = std::move(zeroRttWriteHeaderCipher);
 
     // If zero rtt write cipher is derived, it means the cached psk was valid
     DCHECK(quicCachedPsk);

--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -75,11 +75,6 @@ std::unique_ptr<Aead> ClientHandshake::getOneRttReadCipher() {
   return std::move(oneRttReadCipher_);
 }
 
-std::unique_ptr<Aead> ClientHandshake::getZeroRttWriteCipher() {
-  throwOnError();
-  return std::move(zeroRttWriteCipher_);
-}
-
 std::unique_ptr<Aead> ClientHandshake::getHandshakeReadCipher() {
   throwOnError();
   return std::move(handshakeReadCipher_);
@@ -112,12 +107,6 @@ std::unique_ptr<PacketNumberCipher>
 ClientHandshake::getHandshakeWriteHeaderCipher() {
   throwOnError();
   return std::move(handshakeWriteHeaderCipher_);
-}
-
-std::unique_ptr<PacketNumberCipher>
-ClientHandshake::getZeroRttWriteHeaderCipher() {
-  throwOnError();
-  return std::move(zeroRttWriteHeaderCipher_);
 }
 
 /**
@@ -165,8 +154,8 @@ void ClientHandshake::computeCiphers(CipherKind kind, folly::ByteRange secret) {
       oneRttReadHeaderCipher_ = std::move(packetNumberCipher);
       break;
     case CipherKind::ZeroRttWrite:
-      zeroRttWriteCipher_ = std::move(aead);
-      zeroRttWriteHeaderCipher_ = std::move(packetNumberCipher);
+      conn_->zeroRttWriteCipher = std::move(aead);
+      conn_->zeroRttWriteHeaderCipher = std::move(packetNumberCipher);
       break;
     default:
       // Report error?

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -69,12 +69,6 @@ class ClientHandshake : public Handshake {
   std::unique_ptr<Aead> getOneRttReadCipher();
 
   /**
-   * An edge triggered API to get the zeroRttWriteCipher. Once you receive the
-   * zero rtt write cipher subsequent calls will return null.
-   */
-  std::unique_ptr<Aead> getZeroRttWriteCipher();
-
-  /**
    * An edge triggered API to get the handshakeReadCipher. Once you
    * receive the handshake read cipher subsequent calls will return null.
    */
@@ -109,12 +103,6 @@ class ClientHandshake : public Handshake {
    * receive the header cipher subsequent calls will return null.
    */
   std::unique_ptr<PacketNumberCipher> getHandshakeWriteHeaderCipher();
-
-  /**
-   * An edge triggered API to get the zero rtt write header cpher. Once you
-   * receive the header cipher subsequent calls will return null.
-   */
-  std::unique_ptr<PacketNumberCipher> getZeroRttWriteHeaderCipher();
 
   /**
    * Returns a reference to the CryptoFactory used internaly.
@@ -165,13 +153,11 @@ class ClientHandshake : public Handshake {
   std::unique_ptr<Aead> handshakeReadCipher_;
   std::unique_ptr<Aead> oneRttReadCipher_;
   std::unique_ptr<Aead> oneRttWriteCipher_;
-  std::unique_ptr<Aead> zeroRttWriteCipher_;
 
   std::unique_ptr<PacketNumberCipher> oneRttReadHeaderCipher_;
   std::unique_ptr<PacketNumberCipher> oneRttWriteHeaderCipher_;
   std::unique_ptr<PacketNumberCipher> handshakeReadHeaderCipher_;
   std::unique_ptr<PacketNumberCipher> handshakeWriteHeaderCipher_;
-  std::unique_ptr<PacketNumberCipher> zeroRttWriteHeaderCipher_;
 
   void computeCiphers(CipherKind kind, folly::ByteRange secret);
 

--- a/quic/client/handshake/FizzClientHandshake.cpp
+++ b/quic/client/handshake/FizzClientHandshake.cpp
@@ -45,6 +45,8 @@ void FizzClientHandshake::connect(
       std::move(hostname),
       std::move(cachedPsk),
       std::make_shared<FizzClientExtensions>(std::move(transportParams))));
+
+  throwOnError();
 }
 
 const CryptoFactory& FizzClientHandshake::getCryptoFactory() const {

--- a/quic/client/handshake/test/ClientHandshakeTest.cpp
+++ b/quic/client/handshake/test/ClientHandshakeTest.cpp
@@ -139,7 +139,7 @@ class ClientHandshakeTest : public Test, public boost::static_visitor<> {
   void processHandshake() {
     auto oneRttWriteCipherTmp = handshake->getOneRttWriteCipher();
     auto oneRttReadCipherTmp = handshake->getOneRttReadCipher();
-    auto zeroRttWriteCipherTmp = handshake->getZeroRttWriteCipher();
+    auto zeroRttWriteCipherTmp = std::move(conn->zeroRttWriteCipher);
     auto handshakeWriteCipherTmp = handshake->getHandshakeWriteCipher();
     auto handshakeReadCipherTmp = handshake->getHandshakeReadCipher();
     if (oneRttWriteCipherTmp) {

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -1187,12 +1187,12 @@ class FakeOneRttHandshakeLayer : public ClientHandshake {
   }
 
   void setZeroRttWriteCipher(std::unique_ptr<Aead> zeroRttWriteCipher) {
-    zeroRttWriteCipher_ = std::move(zeroRttWriteCipher);
+    conn_->zeroRttWriteCipher = std::move(zeroRttWriteCipher);
   }
 
   void setZeroRttWriteHeaderCipher(
       std::unique_ptr<PacketNumberCipher> zeroRttWriteHeaderCipher) {
-    zeroRttWriteHeaderCipher_ = std::move(zeroRttWriteHeaderCipher);
+    conn_->zeroRttWriteHeaderCipher = std::move(zeroRttWriteHeaderCipher);
   }
 
   void setHandshakeReadHeaderCipher(


### PR DESCRIPTION
Make sure that trigger on error is performed when running connect.

This avoids some bucket brigading around the connect function and helps to isolate QuicClientTransport pskCache management, reduce the memory footprint of the handhsake and reduce temporal coupling.