### PR TITLE
Populate QuicReadCodec's cipher from the client's handshake directly

### DIFF
--- a/quic/client/QuicClientTransport.cpp
+++ b/quic/client/QuicClientTransport.cpp
@@ -515,19 +515,7 @@ void QuicClientTransport::processPacketData(
   auto handshakeLayer = clientConn_->clientHandshakeLayer;
   if (cryptoData) {
     handshakeLayer->doHandshake(std::move(cryptoData), encryptionLevel);
-    auto handshakeReadCipher = handshakeLayer->getHandshakeReadCipher();
-    auto handshakeReadHeaderCipher =
-        handshakeLayer->getHandshakeReadHeaderCipher();
-    if (handshakeReadCipher) {
-      conn_->readCodec->setHandshakeReadCipher(std::move(handshakeReadCipher));
-    }
-    if (handshakeReadHeaderCipher) {
-      conn_->readCodec->setHandshakeHeaderCipher(
-          std::move(handshakeReadHeaderCipher));
-    }
     auto oneRttWriteCipher = handshakeLayer->getOneRttWriteCipher();
-    auto oneRttReadCipher = handshakeLayer->getOneRttReadCipher();
-    auto oneRttReadHeaderCipher = handshakeLayer->getOneRttReadHeaderCipher();
     auto oneRttWriteHeaderCipher = handshakeLayer->getOneRttWriteHeaderCipher();
     bool oneRttKeyDerivationTriggered = false;
     if (oneRttWriteCipher) {
@@ -537,13 +525,6 @@ void QuicClientTransport::processPacketData(
     }
     if (oneRttWriteHeaderCipher) {
       conn_->oneRttWriteHeaderCipher = std::move(oneRttWriteHeaderCipher);
-    }
-    if (oneRttReadCipher) {
-      conn_->readCodec->setOneRttReadCipher(std::move(oneRttReadCipher));
-    }
-    if (oneRttReadHeaderCipher) {
-      conn_->readCodec->setOneRttHeaderCipher(
-          std::move(oneRttReadHeaderCipher));
     }
     bool zeroRttRejected = handshakeLayer->getZeroRttRejected().value_or(false);
     if (zeroRttRejected) {

--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -70,32 +70,10 @@ std::unique_ptr<Aead> ClientHandshake::getOneRttWriteCipher() {
   return std::move(oneRttWriteCipher_);
 }
 
-std::unique_ptr<Aead> ClientHandshake::getOneRttReadCipher() {
-  throwOnError();
-  return std::move(oneRttReadCipher_);
-}
-
-std::unique_ptr<Aead> ClientHandshake::getHandshakeReadCipher() {
-  throwOnError();
-  return std::move(handshakeReadCipher_);
-}
-
-std::unique_ptr<PacketNumberCipher>
-ClientHandshake::getOneRttReadHeaderCipher() {
-  throwOnError();
-  return std::move(oneRttReadHeaderCipher_);
-}
-
 std::unique_ptr<PacketNumberCipher>
 ClientHandshake::getOneRttWriteHeaderCipher() {
   throwOnError();
   return std::move(oneRttWriteHeaderCipher_);
-}
-
-std::unique_ptr<PacketNumberCipher>
-ClientHandshake::getHandshakeReadHeaderCipher() {
-  throwOnError();
-  return std::move(handshakeReadHeaderCipher_);
 }
 
 /**
@@ -131,16 +109,17 @@ void ClientHandshake::computeCiphers(CipherKind kind, folly::ByteRange secret) {
       conn_->handshakeWriteHeaderCipher = std::move(packetNumberCipher);
       break;
     case CipherKind::HandshakeRead:
-      handshakeReadCipher_ = std::move(aead);
-      handshakeReadHeaderCipher_ = std::move(packetNumberCipher);
+      conn_->readCodec->setHandshakeReadCipher(std::move(aead));
+      conn_->readCodec->setHandshakeHeaderCipher(std::move(packetNumberCipher));
       break;
     case CipherKind::OneRttWrite:
       oneRttWriteCipher_ = std::move(aead);
       oneRttWriteHeaderCipher_ = std::move(packetNumberCipher);
       break;
     case CipherKind::OneRttRead:
-      oneRttReadCipher_ = std::move(aead);
-      oneRttReadHeaderCipher_ = std::move(packetNumberCipher);
+      conn_->readCodec->setOneRttReadCipher(std::move(aead));
+      conn_->readCodec->setOneRttHeaderCipher(
+          std::move(packetNumberCipher));
       break;
     case CipherKind::ZeroRttWrite:
       conn_->zeroRttWriteCipher = std::move(aead);

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -63,34 +63,10 @@ class ClientHandshake : public Handshake {
   std::unique_ptr<Aead> getOneRttWriteCipher();
 
   /**
-   * An edge triggered API to get the oneRttReadCipher. Once you receive the
-   * read cipher subsequent calls will return null.
-   */
-  std::unique_ptr<Aead> getOneRttReadCipher();
-
-  /**
-   * An edge triggered API to get the handshakeReadCipher. Once you
-   * receive the handshake read cipher subsequent calls will return null.
-   */
-  std::unique_ptr<Aead> getHandshakeReadCipher();
-
-  /**
-   * An edge triggered API to get the one rtt read header cpher. Once you
-   * receive the header cipher subsequent calls will return null.
-   */
-  std::unique_ptr<PacketNumberCipher> getOneRttReadHeaderCipher();
-
-  /**
    * An edge triggered API to get the one rtt write header cpher. Once you
    * receive the header cipher subsequent calls will return null.
    */
   std::unique_ptr<PacketNumberCipher> getOneRttWriteHeaderCipher();
-
-  /**
-   * An edge triggered API to get the handshake rtt read header cpher. Once you
-   * receive the header cipher subsequent calls will return null.
-   */
-  std::unique_ptr<PacketNumberCipher> getHandshakeReadHeaderCipher();
 
   /**
    * Returns a reference to the CryptoFactory used internaly.
@@ -137,13 +113,9 @@ class ClientHandshake : public Handshake {
     ZeroRttWrite,
   };
 
-  std::unique_ptr<Aead> handshakeReadCipher_;
-  std::unique_ptr<Aead> oneRttReadCipher_;
   std::unique_ptr<Aead> oneRttWriteCipher_;
 
-  std::unique_ptr<PacketNumberCipher> oneRttReadHeaderCipher_;
   std::unique_ptr<PacketNumberCipher> oneRttWriteHeaderCipher_;
-  std::unique_ptr<PacketNumberCipher> handshakeReadHeaderCipher_;
 
   void computeCiphers(CipherKind kind, folly::ByteRange secret);
 

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -1138,11 +1138,11 @@ class FakeOneRttHandshakeLayer : public ClientHandshake {
   }
 
   void setOneRttReadCipher(std::unique_ptr<Aead> oneRttReadCipher) {
-    oneRttReadCipher_ = std::move(oneRttReadCipher);
+    conn_->readCodec->setOneRttReadCipher(std::move(oneRttReadCipher));
   }
 
   void setHandshakeReadCipher(std::unique_ptr<Aead> handshakeReadCipher) {
-    handshakeReadCipher_ = std::move(handshakeReadCipher);
+    conn_->readCodec->setHandshakeReadCipher(std::move(handshakeReadCipher));
   }
 
   void setHandshakeWriteCipher(std::unique_ptr<Aead> handshakeWriteCipher) {
@@ -1160,7 +1160,8 @@ class FakeOneRttHandshakeLayer : public ClientHandshake {
 
   void setHandshakeReadHeaderCipher(
       std::unique_ptr<PacketNumberCipher> handshakeReadHeaderCipher) {
-    handshakeReadHeaderCipher_ = std::move(handshakeReadHeaderCipher);
+    conn_->readCodec->setHandshakeHeaderCipher(
+        std::move(handshakeReadHeaderCipher));
   }
 
   void setHandshakeWriteHeaderCipher(
@@ -1175,7 +1176,8 @@ class FakeOneRttHandshakeLayer : public ClientHandshake {
 
   void setOneRttReadHeaderCipher(
       std::unique_ptr<PacketNumberCipher> oneRttReadHeaderCipher) {
-    oneRttReadHeaderCipher_ = std::move(oneRttReadHeaderCipher);
+    conn_->readCodec->setOneRttHeaderCipher(
+          std::move(oneRttReadHeaderCipher));
   }
 
   void setZeroRttRejected() {


### PR DESCRIPTION
This is a continuation of #98 and depends on it.