### PR TITLE
Move peer advertised transport parameter to QuicClientConnectionState

### DIFF
--- a/quic/client/QuicClientTransport.cpp
+++ b/quic/client/QuicClientTransport.cpp
@@ -919,12 +919,12 @@ void QuicClientTransport::cacheServerInitialParams(
     uint64_t peerAdvertisedInitialMaxStreamsBidi,
     uint64_t peerAdvertisedInitialMaxStreamUni) {
   serverInitialParamsSet_ = true;
-  peerAdvertisedInitialMaxData_ = peerAdvertisedInitialMaxData;
-  peerAdvertisedInitialMaxStreamDataBidiLocal_ =
+  clientConn_->peerAdvertisedInitialMaxData = peerAdvertisedInitialMaxData;
+  clientConn_->peerAdvertisedInitialMaxStreamDataBidiLocal =
       peerAdvertisedInitialMaxStreamDataBidiLocal;
-  peerAdvertisedInitialMaxStreamDataBidiRemote_ =
+  clientConn_->peerAdvertisedInitialMaxStreamDataBidiRemote =
       peerAdvertisedInitialMaxStreamDataBidiRemote;
-  peerAdvertisedInitialMaxStreamDataUni_ =
+  clientConn_->peerAdvertisedInitialMaxStreamDataUni =
       peerAdvertisedInitialMaxStreamDataUni;
   clientConn_->peerAdvertisedInitialMaxStreamsBidi =
       peerAdvertisedInitialMaxStreamsBidi;
@@ -952,13 +952,14 @@ void QuicClientTransport::onNewCachedPsk(
 
   quicCachedPsk.transportParams.idleTimeout = conn_->peerIdleTimeout.count();
   quicCachedPsk.transportParams.maxRecvPacketSize = conn_->udpSendPacketLen;
-  quicCachedPsk.transportParams.initialMaxData = peerAdvertisedInitialMaxData_;
+  quicCachedPsk.transportParams.initialMaxData =
+      clientConn_->peerAdvertisedInitialMaxData;
   quicCachedPsk.transportParams.initialMaxStreamDataBidiLocal =
-      peerAdvertisedInitialMaxStreamDataBidiLocal_;
+      clientConn_->peerAdvertisedInitialMaxStreamDataBidiLocal;
   quicCachedPsk.transportParams.initialMaxStreamDataBidiRemote =
-      peerAdvertisedInitialMaxStreamDataBidiRemote_;
+      clientConn_->peerAdvertisedInitialMaxStreamDataBidiRemote;
   quicCachedPsk.transportParams.initialMaxStreamDataUni =
-      peerAdvertisedInitialMaxStreamDataUni_;
+      clientConn_->peerAdvertisedInitialMaxStreamDataUni;
   quicCachedPsk.transportParams.initialMaxStreamsBidi =
       clientConn_->peerAdvertisedInitialMaxStreamsBidi;
   quicCachedPsk.transportParams.initialMaxStreamsUni =

--- a/quic/client/QuicClientTransport.h
+++ b/quic/client/QuicClientTransport.h
@@ -208,10 +208,6 @@ class QuicClientTransport
   folly::Optional<std::string> hostname_;
   HappyEyeballsConnAttemptDelayTimeout happyEyeballsConnAttemptDelayTimeout_;
   bool serverInitialParamsSet_{false};
-  uint64_t peerAdvertisedInitialMaxData_{0};
-  uint64_t peerAdvertisedInitialMaxStreamDataBidiLocal_{0};
-  uint64_t peerAdvertisedInitialMaxStreamDataBidiRemote_{0};
-  uint64_t peerAdvertisedInitialMaxStreamDataUni_{0};
 
  private:
   void cacheServerInitialParams(

--- a/quic/client/state/ClientStateMachine.h
+++ b/quic/client/state/ClientStateMachine.h
@@ -38,6 +38,10 @@ struct QuicClientConnectionState : public QuicConnectionStateBase {
   // Save the server transport params here so that client can access the value
   // when it wants to write the values to psk cache
   // TODO Save TicketTransportParams here instead of in QuicClientTransport
+  uint64_t peerAdvertisedInitialMaxData{0};
+  uint64_t peerAdvertisedInitialMaxStreamDataBidiLocal{0};
+  uint64_t peerAdvertisedInitialMaxStreamDataBidiRemote{0};
+  uint64_t peerAdvertisedInitialMaxStreamDataUni{0};
   uint64_t peerAdvertisedInitialMaxStreamsBidi{0};
   uint64_t peerAdvertisedInitialMaxStreamsUni{0};
 

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -145,19 +145,19 @@ class TestingQuicClientTransport : public QuicClientTransport {
   }
 
   auto& peerAdvertisedInitialMaxData() {
-    return peerAdvertisedInitialMaxData_;
+    return getConn().peerAdvertisedInitialMaxData;
   }
 
   auto& peerAdvertisedInitialMaxStreamDataBidiLocal() const {
-    return peerAdvertisedInitialMaxStreamDataBidiLocal_;
+    return getConn().peerAdvertisedInitialMaxStreamDataBidiLocal;
   }
 
   auto& peerAdvertisedInitialMaxStreamDataBidiRemote() const {
-    return peerAdvertisedInitialMaxStreamDataBidiRemote_;
+    return getConn().peerAdvertisedInitialMaxStreamDataBidiRemote;
   }
 
   auto& peerAdvertisedInitialMaxStreamDataUni() const {
-    return peerAdvertisedInitialMaxStreamDataUni_;
+    return getConn().peerAdvertisedInitialMaxStreamDataUni;
   }
 
   void setDestructionCallback(


### PR DESCRIPTION
Some of these parameters are already there. The other need to be move so that the can be accessed when caching new public keys.