### PR TITLE
Use a template method pattern for ClientHandshake::connect

### DIFF
--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -17,6 +17,19 @@ namespace quic {
 ClientHandshake::ClientHandshake(QuicClientConnectionState* conn)
     : conn_(conn) {}
 
+void ClientHandshake::connect(
+    folly::Optional<std::string> hostname,
+    folly::Optional<fizz::client::CachedPsk> cachedPsk,
+    std::shared_ptr<ClientTransportParametersExtension> transportParams,
+    HandshakeCallback* callback) {
+  transportParams_ = std::move(transportParams);
+  callback_ = callback;
+
+  connectImpl(std::move(hostname), std::move(cachedPsk));
+
+  throwOnError();
+}
+
 void ClientHandshake::doHandshake(
     std::unique_ptr<folly::IOBuf> data,
     EncryptionLevel encryptionLevel) {

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -42,11 +42,11 @@ class ClientHandshake : public Handshake {
   /**
    * Initiate the handshake with the supplied parameters.
    */
-  virtual void connect(
+  void connect(
       folly::Optional<std::string> hostname,
       folly::Optional<fizz::client::CachedPsk> cachedPsk,
       std::shared_ptr<ClientTransportParametersExtension> transportParams,
-      HandshakeCallback* callback) = 0;
+      HandshakeCallback* callback);
 
   /**
    * Takes input bytes from the network and processes then in the handshake.
@@ -119,6 +119,10 @@ class ClientHandshake : public Handshake {
   void computeOneRttCipher(bool earlyDataAccepted);
 
  private:
+  virtual void connectImpl(
+      folly::Optional<std::string> hostname,
+      folly::Optional<fizz::client::CachedPsk> cachedPsk) = 0;
+
   virtual EncryptionLevel getReadRecordLayerEncryptionLevel() = 0;
   virtual void processSocketData(folly::IOBufQueue& queue) = 0;
   virtual bool matchEarlyParameters() = 0;

--- a/quic/client/handshake/FizzClientHandshake.cpp
+++ b/quic/client/handshake/FizzClientHandshake.cpp
@@ -22,14 +22,9 @@ FizzClientHandshake::FizzClientHandshake(
     std::shared_ptr<FizzClientQuicHandshakeContext> fizzContext)
     : ClientHandshake(conn), fizzContext_(std::move(fizzContext)) {}
 
-void FizzClientHandshake::connect(
+void FizzClientHandshake::connectImpl(
     folly::Optional<std::string> hostname,
-    folly::Optional<fizz::client::CachedPsk> cachedPsk,
-    std::shared_ptr<ClientTransportParametersExtension> transportParams,
-    HandshakeCallback* callback) {
-  transportParams_ = transportParams;
-  callback_ = callback;
-
+    folly::Optional<fizz::client::CachedPsk> cachedPsk) {
   // Setup context for this handshake.
   auto context = std::make_shared<fizz::client::FizzClientContext>(
       *fizzContext_->getContext());
@@ -44,9 +39,7 @@ void FizzClientHandshake::connect(
       fizzContext_->getCertificateVerifier(),
       std::move(hostname),
       std::move(cachedPsk),
-      std::make_shared<FizzClientExtensions>(std::move(transportParams))));
-
-  throwOnError();
+      std::make_shared<FizzClientExtensions>(transportParams_)));
 }
 
 const CryptoFactory& FizzClientHandshake::getCryptoFactory() const {

--- a/quic/client/handshake/FizzClientHandshake.h
+++ b/quic/client/handshake/FizzClientHandshake.h
@@ -22,12 +22,6 @@ class FizzClientHandshake : public ClientHandshake {
       QuicClientConnectionState* conn,
       std::shared_ptr<FizzClientQuicHandshakeContext> fizzContext);
 
-  void connect(
-      folly::Optional<std::string> hostname,
-      folly::Optional<fizz::client::CachedPsk> cachedPsk,
-      std::shared_ptr<ClientTransportParametersExtension> transportParams,
-      HandshakeCallback* callback) override;
-
   const CryptoFactory& getCryptoFactory() const override;
 
   const folly::Optional<std::string>& getApplicationProtocol() const override;
@@ -35,6 +29,10 @@ class FizzClientHandshake : public ClientHandshake {
   bool isTLSResumed() const override;
 
  private:
+  void connectImpl(
+      folly::Optional<std::string> hostname,
+      folly::Optional<fizz::client::CachedPsk> cachedPsk) override;
+
   EncryptionLevel getReadRecordLayerEncryptionLevel() override;
   void processSocketData(folly::IOBufQueue& queue) override;
   bool matchEarlyParameters() override;

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -1088,16 +1088,13 @@ class FakeOneRttHandshakeLayer : public ClientHandshake {
   explicit FakeOneRttHandshakeLayer(QuicClientConnectionState* conn)
       : ClientHandshake(conn) {}
 
-  void connect(
+  void connectImpl(
       folly::Optional<std::string>,
-      folly::Optional<fizz::client::CachedPsk>,
-      std::shared_ptr<ClientTransportParametersExtension>,
-      HandshakeCallback* callback) override {
+      folly::Optional<fizz::client::CachedPsk>) override {
     connected_ = true;
     writeDataToQuicStream(
         conn_->cryptoState->initialStream, IOBuf::copyBuffer("CHLO"));
     createServerTransportParameters();
-    callback_ = callback;
   }
 
   void createServerTransportParameters() {


### PR DESCRIPTION
This ensures we have a place to plug things into the connect method that do not depend on the actual handshake implementation.