### PR TITLE
Use the PskCache from the context rather than the transport

### DIFF
--- a/quic/client/QuicClientTransport.h
+++ b/quic/client/QuicClientTransport.h
@@ -80,12 +80,6 @@ class QuicClientTransport
   virtual void setHappyEyeballsCachedFamily(sa_family_t cachedFamily);
 
   /**
-   * Set the cache that remembers psk and server transport parameters from
-   * last connection. This is useful for session resumption and 0-rtt.
-   */
-  void setPskCache(std::shared_ptr<QuicPskCache> pskCache);
-
-  /**
    * Starts the connection.
    */
   virtual void start(ConnectionCallback* cb);
@@ -211,7 +205,6 @@ class QuicClientTransport
 
  private:
   folly::Optional<QuicCachedPsk> getPsk();
-  void removePsk();
   void setPartialReliabilityTransportParameter();
 
   bool replaySafeNotified_{false};
@@ -220,7 +213,6 @@ class QuicClientTransport
   std::shared_ptr<QuicClientTransport> selfOwning_;
   bool happyEyeballsEnabled_{false};
   sa_family_t happyEyeballsCachedFamily_{AF_UNSPEC};
-  std::shared_ptr<QuicPskCache> pskCache_;
   QuicClientConnectionState* clientConn_;
   std::vector<TransportParameter> customTransportParameters_;
   folly::SocketOptionMap socketOptions_;

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -16,6 +16,7 @@
 
 #include <quic/QuicConstants.h>
 #include <quic/QuicException.h>
+#include <quic/client/handshake/QuicPskCache.h>
 #include <quic/handshake/Aead.h>
 #include <quic/handshake/HandshakeLayer.h>
 
@@ -56,6 +57,19 @@ class ClientHandshake : public Handshake {
   virtual void doHandshake(
       std::unique_ptr<folly::IOBuf> data,
       EncryptionLevel encryptionLevel);
+
+  /**
+   * Provides facilities to get, put and remove a PSK from the cache in case the
+   * handshake supports a PSK cache.
+   */
+  virtual folly::Optional<QuicCachedPsk> getPsk(
+      const folly::Optional<std::string>& /* hostname */) const {
+    return folly::none;
+  }
+  virtual void putPsk(
+      const folly::Optional<std::string>& /* hostname */,
+      QuicCachedPsk /* quicCachedPsk */) {}
+  virtual void removePsk(const folly::Optional<std::string>& /* hostname */) {}
 
   /**
    * Returns a reference to the CryptoFactory used internaly.

--- a/quic/client/handshake/FizzClientHandshake.cpp
+++ b/quic/client/handshake/FizzClientHandshake.cpp
@@ -42,6 +42,22 @@ void FizzClientHandshake::connectImpl(
       std::make_shared<FizzClientExtensions>(transportParams_)));
 }
 
+folly::Optional<QuicCachedPsk> FizzClientHandshake::getPsk(
+    const folly::Optional<std::string>& hostname) const {
+  return fizzContext_->getPsk(hostname);
+}
+
+void FizzClientHandshake::putPsk(
+    const folly::Optional<std::string>& hostname,
+    QuicCachedPsk quicCachedPsk) {
+  fizzContext_->putPsk(hostname, std::move(quicCachedPsk));
+}
+
+void FizzClientHandshake::removePsk(
+    const folly::Optional<std::string>& hostname) {
+  fizzContext_->removePsk(hostname);
+}
+
 const CryptoFactory& FizzClientHandshake::getCryptoFactory() const {
   return cryptoFactory_;
 }

--- a/quic/client/handshake/FizzClientHandshake.h
+++ b/quic/client/handshake/FizzClientHandshake.h
@@ -22,6 +22,13 @@ class FizzClientHandshake : public ClientHandshake {
       QuicClientConnectionState* conn,
       std::shared_ptr<FizzClientQuicHandshakeContext> fizzContext);
 
+  folly::Optional<QuicCachedPsk> getPsk(
+      const folly::Optional<std::string>& hostname) const override;
+  void putPsk(
+      const folly::Optional<std::string>& hostname,
+      QuicCachedPsk quicCachedPsk) override;
+  void removePsk(const folly::Optional<std::string>& hostname) override;
+
   const CryptoFactory& getCryptoFactory() const override;
 
   const folly::Optional<std::string>& getApplicationProtocol() const override;

--- a/quic/client/handshake/FizzClientQuicHandshakeContext.cpp
+++ b/quic/client/handshake/FizzClientQuicHandshakeContext.cpp
@@ -35,6 +35,14 @@ folly::Optional<QuicCachedPsk> FizzClientQuicHandshakeContext::getPsk(
   return pskCache_->getPsk(*hostname);
 }
 
+void FizzClientQuicHandshakeContext::putPsk(
+    const folly::Optional<std::string>& hostname,
+    QuicCachedPsk quicCachedPsk) {
+  if (hostname && pskCache_) {
+    pskCache_->putPsk(*hostname, std::move(quicCachedPsk));
+  }
+}
+
 void FizzClientQuicHandshakeContext::removePsk(
     const folly::Optional<std::string>& hostname) {
   if (hostname && pskCache_) {

--- a/quic/client/handshake/FizzClientQuicHandshakeContext.h
+++ b/quic/client/handshake/FizzClientQuicHandshakeContext.h
@@ -38,6 +38,9 @@ class FizzClientQuicHandshakeContext
 
   folly::Optional<QuicCachedPsk> getPsk(
       const folly::Optional<std::string>& hostname);
+  void putPsk(
+      const folly::Optional<std::string>& hostname,
+      QuicCachedPsk quicCachedPsk);
   void removePsk(const folly::Optional<std::string>& hostname);
 
  private:


### PR DESCRIPTION
The cache is obviously dependent on the crypto that is used. It's management needs to be moved down to part of the code that are specific to the crypto used. As a first step, we remove the cache from the transport, and use the one from the fizz context - if available - through the handshake.