### PR TITLE
Do post connect update of cached server params in the handshake rather than the transport

### DIFF
--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -24,6 +24,7 @@ namespace quic {
 
 class CryptoFactory;
 struct ClientTransportParametersExtension;
+struct QuicCachedPsk;
 struct QuicClientConnectionState;
 struct ServerTransportParameters;
 
@@ -45,7 +46,7 @@ class ClientHandshake : public Handshake {
    */
   void connect(
       folly::Optional<std::string> hostname,
-      folly::Optional<fizz::client::CachedPsk> cachedPsk,
+      folly::Optional<QuicCachedPsk> quicCachedPsk,
       std::shared_ptr<ClientTransportParametersExtension> transportParams,
       HandshakeCallback* callback);
 

--- a/quic/client/handshake/FizzClientHandshake.cpp
+++ b/quic/client/handshake/FizzClientHandshake.cpp
@@ -10,6 +10,7 @@
 
 #include <quic/client/handshake/FizzClientExtensions.h>
 #include <quic/client/handshake/FizzClientQuicHandshakeContext.h>
+#include <quic/client/state/ClientStateMachine.h>
 #include <quic/fizz/handshake/FizzBridge.h>
 
 #include <fizz/client/EarlyDataRejectionPolicy.h>

--- a/quic/client/handshake/test/ClientHandshakeTest.cpp
+++ b/quic/client/handshake/test/ClientHandshakeTest.cpp
@@ -476,7 +476,7 @@ class ClientHandshakeZeroRttTest : public ClientHandshakeTest {
   void connect() override {
     handshake->connect(
         hostname,
-        psk.cachedPsk,
+        psk,
         std::make_shared<ClientTransportParametersExtension>(
             QuicVersion::MVFST,
             folly::to<uint32_t>(kDefaultConnectionWindowSize),


### PR DESCRIPTION
The cache entry contains the key itself, which is fizz dependent and crypto agnostic infos. We are moving the crypto agnostic infos to the Handshake. Next step is to move the crypto specific infos to the proper handshake subclass.