### PR TITLE
Kill undoAllClientStateCommon

### DIFF
--- a/quic/client/state/ClientStateMachine.cpp
+++ b/quic/client/state/ClientStateMachine.cpp
@@ -19,7 +19,7 @@
 
 namespace quic {
 
-std::unique_ptr<QuicClientConnectionState> undoAllClientStateCommon(
+std::unique_ptr<QuicClientConnectionState> undoAllClientStateForRetry(
     std::unique_ptr<QuicClientConnectionState> conn) {
   // Create a new connection state and copy over properties that don't change
   // across stateless retry.
@@ -50,11 +50,6 @@ std::unique_ptr<QuicClientConnectionState> undoAllClientStateCommon(
   newConn->readCodec->setCodecParameters(CodecParameters(
       conn->peerAckDelayExponent, conn->originalVersion.value()));
   return newConn;
-}
-
-std::unique_ptr<QuicClientConnectionState> undoAllClientStateForRetry(
-    std::unique_ptr<QuicClientConnectionState> conn) {
-  return undoAllClientStateCommon(std::move(conn));
 }
 
 void processServerInitialParams(

--- a/quic/client/state/ClientStateMachine.h
+++ b/quic/client/state/ClientStateMachine.h
@@ -79,9 +79,6 @@ struct QuicClientConnectionState : public QuicConnectionStateBase {
 /**
  * Undos the clients state to be the original state of the client.
  */
-std::unique_ptr<QuicClientConnectionState> undoAllClientStateCommon(
-    std::unique_ptr<QuicClientConnectionState> conn);
-
 std::unique_ptr<QuicClientConnectionState> undoAllClientStateForRetry(
     std::unique_ptr<QuicClientConnectionState> conn);
 


### PR DESCRIPTION
It is not used anywhere.