### PR TITLE
Move onNewCachedPsk down to FizzClientHandshake

### DIFF
--- a/quic/client/QuicClientTransport.cpp
+++ b/quic/client/QuicClientTransport.cpp
@@ -822,7 +822,7 @@ void QuicClientTransport::startCryptoHandshake() {
       conn_->transportSettings.selfActiveConnectionIdLimit,
       customTransportParameters_);
   conn_->transportParametersEncoded = true;
-  handshakeLayer->connect(hostname_, std::move(paramsExtension), this);
+  handshakeLayer->connect(hostname_, std::move(paramsExtension));
 
   writeSocketData();
   if (!transportReadyNotified_ && clientConn_->zeroRttWriteCipher) {
@@ -834,27 +834,6 @@ void QuicClientTransport::startCryptoHandshake() {
       }
     });
   }
-}
-
-void QuicClientTransport::onNewCachedPsk(
-    fizz::client::NewCachedPsk& newCachedPsk) noexcept {
-  DCHECK(conn_->version.has_value());
-  DCHECK(clientConn_->serverInitialParamsSet_);
-
-  QuicCachedPsk quicCachedPsk;
-  quicCachedPsk.cachedPsk = std::move(newCachedPsk.psk);
-  quicCachedPsk.transportParams =
-      getServerCachedTransportParameters(*clientConn_);
-
-  if (conn_->earlyDataAppParamsGetter) {
-    auto appParams = conn_->earlyDataAppParamsGetter();
-    if (appParams) {
-      quicCachedPsk.appParams = appParams->moveToFbString().toStdString();
-    }
-  }
-
-  clientConn_->clientHandshakeLayer->putPsk(
-      *hostname_, std::move(quicCachedPsk));
 }
 
 bool QuicClientTransport::hasWriteCipher() const {

--- a/quic/client/QuicClientTransport.h
+++ b/quic/client/QuicClientTransport.h
@@ -26,8 +26,7 @@ class QuicClientTransport
     : public QuicTransportBase,
       public folly::AsyncUDPSocket::ReadCallback,
       public folly::AsyncUDPSocket::ErrMessageCallback,
-      public std::enable_shared_from_this<QuicClientTransport>,
-      private ClientHandshake::HandshakeCallback {
+      public std::enable_shared_from_this<QuicClientTransport> {
  public:
   QuicClientTransport(
       folly::EventBase* evb,
@@ -194,10 +193,6 @@ class QuicClientTransport
       const OutstandingPacket& outstandingPacket,
       const QuicWriteFrame& packetFrame,
       const ReadAckFrame&);
-
-  // From ClientHandshake::HandshakeCallback
-  void onNewCachedPsk(
-      fizz::client::NewCachedPsk& newCachedPsk) noexcept override;
 
   Buf readBuffer_;
   folly::Optional<std::string> hostname_;

--- a/quic/client/handshake/ClientHandshake.cpp
+++ b/quic/client/handshake/ClientHandshake.cpp
@@ -20,10 +20,8 @@ ClientHandshake::ClientHandshake(QuicClientConnectionState* conn)
 
 void ClientHandshake::connect(
     folly::Optional<std::string> hostname,
-    std::shared_ptr<ClientTransportParametersExtension> transportParams,
-    HandshakeCallback* callback) {
+    std::shared_ptr<ClientTransportParametersExtension> transportParams) {
   transportParams_ = std::move(transportParams);
-  callback_ = callback;
 
   folly::Optional<CachedServerTransportParameters> cachedServerTransportParams =
       connectImpl(std::move(hostname));

--- a/quic/client/handshake/FizzClientHandshake.h
+++ b/quic/client/handshake/FizzClientHandshake.h
@@ -11,9 +11,12 @@
 #include <quic/client/handshake/ClientHandshake.h>
 #include <quic/fizz/handshake/FizzCryptoFactory.h>
 
+#include <fizz/client/ClientProtocol.h>
+
 namespace quic {
 
 class FizzClientQuicHandshakeContext;
+struct QuicCachedPsk;
 struct QuicClientConnectionState;
 
 class FizzClientHandshake : public ClientHandshake {
@@ -22,9 +25,6 @@ class FizzClientHandshake : public ClientHandshake {
       QuicClientConnectionState* conn,
       std::shared_ptr<FizzClientQuicHandshakeContext> fizzContext);
 
-  void putPsk(
-      const folly::Optional<std::string>& hostname,
-      QuicCachedPsk quicCachedPsk) override;
   void removePsk(const folly::Optional<std::string>& hostname) override;
 
   const CryptoFactory& getCryptoFactory() const override;
@@ -36,6 +36,13 @@ class FizzClientHandshake : public ClientHandshake {
  protected:
   folly::Optional<QuicCachedPsk> getPsk(
       const folly::Optional<std::string>& hostname) const;
+
+  void onNewCachedPsk(fizz::client::NewCachedPsk& newCachedPsk) noexcept;
+
+  // For tests.
+  fizz::client::State& getFizzState() {
+    return state_;
+  }
 
  private:
   folly::Optional<CachedServerTransportParameters> connectImpl(

--- a/quic/client/handshake/test/ClientHandshakeTest.cpp
+++ b/quic/client/handshake/test/ClientHandshakeTest.cpp
@@ -70,8 +70,7 @@ class ClientHandshakeTest : public Test, public boost::static_visitor<> {
             kDefaultIdleTimeout,
             kDefaultAckDelayExponent,
             kDefaultUDPSendPacketLen,
-            kDefaultActiveConnectionIdLimit),
-        nullptr);
+            kDefaultActiveConnectionIdLimit));
   }
 
   void SetUp() override {
@@ -342,16 +341,6 @@ TEST_F(ClientHandshakeTest, TestAppBytesInterpretedAsHandshake) {
   EXPECT_TRUE(handshakeSuccess);
 }
 
-class MockClientHandshakeCallback : public ClientHandshake::HandshakeCallback {
- public:
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      onNewCachedPsk,
-      void(fizz::client::NewCachedPsk&));
-};
-
 class ClientHandshakeCallbackTest : public ClientHandshakeTest {
  public:
   void setupClientAndServerContext() override {
@@ -376,13 +365,11 @@ class ClientHandshakeCallbackTest : public ClientHandshakeTest {
             kDefaultIdleTimeout,
             kDefaultAckDelayExponent,
             kDefaultUDPSendPacketLen,
-            kDefaultActiveConnectionIdLimit),
-        &mockClientHandshakeCallback_);
+            kDefaultActiveConnectionIdLimit));
   }
 
  protected:
   QuicCachedPsk psk_;
-  MockClientHandshakeCallback mockClientHandshakeCallback_;
 };
 
 TEST_F(ClientHandshakeCallbackTest, TestHandshakeSuccess) {
@@ -390,8 +377,14 @@ TEST_F(ClientHandshakeCallbackTest, TestHandshakeSuccess) {
   serverClientRound();
   clientServerRound();
 
-  EXPECT_CALL(mockClientHandshakeCallback_, onNewCachedPsk(_));
+  bool gotEarlyDataParams = false;
+  conn->earlyDataAppParamsGetter = [&]() -> Buf {
+    gotEarlyDataParams = true;
+    return {};
+  };
+
   serverClientRound();
+  EXPECT_TRUE(gotEarlyDataParams);
 }
 
 class ClientHandshakeHRRTest : public ClientHandshakeTest {
@@ -483,8 +476,7 @@ class ClientHandshakeZeroRttTest : public ClientHandshakeTest {
             kDefaultIdleTimeout,
             kDefaultAckDelayExponent,
             kDefaultUDPSendPacketLen,
-            kDefaultActiveConnectionIdLimit),
-        nullptr);
+            kDefaultActiveConnectionIdLimit));
   }
 
   virtual void setupZeroRttServer() {

--- a/quic/client/test/QuicClientTransportTest.cpp
+++ b/quic/client/test/QuicClientTransportTest.cpp
@@ -1096,6 +1096,8 @@ class FakeOneRttHandshakeLayer : public FizzClientHandshake {
       transportParams = std::move(quicCachedPsk->transportParams);
     }
 
+    getFizzState().sni() = hostname;
+
     connected_ = true;
     writeDataToQuicStream(
         conn_->cryptoState->initialStream, IOBuf::copyBuffer("CHLO"));
@@ -1221,7 +1223,7 @@ class FakeOneRttHandshakeLayer : public FizzClientHandshake {
 
   void triggerOnNewCachedPsk() {
     fizz::client::NewCachedPsk psk;
-    callback_->onNewCachedPsk(psk);
+    onNewCachedPsk(psk);
   }
 
   std::unique_ptr<folly::IOBuf> writeBuf;


### PR DESCRIPTION
This is the last step toward separating fizz from the generic client code.

Depends on #114 