### PR TITLE
update: build_helper.sh add --depth=10 for git clone

### DIFF
--- a/build_helper.sh
+++ b/build_helper.sh
@@ -165,7 +165,7 @@ function setup_fmt() {
 
   if [ ! -d "$FMT_DIR" ] ; then
     echo -e "${COLOR_GREEN}[ INFO ] Cloning fmt repo ${COLOR_OFF}"
-    git clone https://github.com/fmtlib/fmt.git  "$FMT_DIR"
+    git clone https://github.com/fmtlib/fmt.git --depth=10  "$FMT_DIR"
   fi
   cd "$FMT_DIR"
   git fetch
@@ -206,7 +206,7 @@ function setup_folly() {
 
   if [ ! -d "$FOLLY_DIR" ] ; then
     echo -e "${COLOR_GREEN}[ INFO ] Cloning folly repo ${COLOR_OFF}"
-    git clone https://github.com/facebook/folly.git "$FOLLY_DIR"
+    git clone https://github.com/facebook/folly.git --depth=10 "$FOLLY_DIR"
     if [[ -z "${MVFST_SKIP_SYSTEM_DEPENDENCIES-}" ]]; then
       echo -e "${COLOR_GREEN}[ INFO ] install dependencies ${COLOR_OFF}"
       if [ "$Platform" = "Linux" ]; then
@@ -256,7 +256,7 @@ function setup_fizz() {
   FIZZ_BUILD_DIR=$DEPS_DIR/fizz/build/
   if [ ! -d "$FIZZ_DIR" ] ; then
     echo -e "${COLOR_GREEN}[ INFO ] Cloning fizz repo ${COLOR_OFF}"
-    git clone https://github.com/facebookincubator/fizz "$FIZZ_DIR"
+    git clone https://github.com/facebookincubator/fizz.git --depth=10 "$FIZZ_DIR"
   fi
 
   synch_dependency_to_commit "$FIZZ_DIR" "$MVFST_ROOT_DIR/build/deps/github_hashes/facebookincubator/fizz-rev.txt"


### PR DESCRIPTION
Only pull the latest 10 commits to speed up git clone for the first time. When there is a version, we use git checkout to get the deps commit. refer to:#128