### PR TITLE
Use C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,12 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-project(
-  mvfst
-)
+project(mvfst)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
   # for in-fbsource builds
@@ -75,11 +78,6 @@ else()
   list(APPEND CMAKE_REQUIRED_LIBRARIES ${LIBGFLAGS_LIBRARY})
   list(APPEND CMAKE_REQUIRED_INCLUDES ${LIBGFLAGS_INCLUDE_DIR})
 endif()
-
-list(APPEND
-  _QUIC_BASE_COMPILE_OPTIONS
-  -std=c++14
-)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
 list(APPEND


### PR DESCRIPTION
Dependencies started using C++17 so it's required by now and it seems there is some ABI breakage with fizz.