### PR TITLE
Remove outdated comment in ClientHandshakeFactory

### DIFF
--- a/quic/client/handshake/ClientHandshakeFactory.h
+++ b/quic/client/handshake/ClientHandshakeFactory.h
@@ -21,9 +21,6 @@ class ClientHandshakeFactory {
 
   /**
    * Construct a new client handshake.
-   * /!\ The ClientHandshake constructed might keep a reference to cryptoState.
-   * It is up to the caller to ensure the lifetime of cryptoState exceed the one
-   * of the ClientHandshake.
    */
   virtual std::unique_ptr<ClientHandshake> makeClientHandshake(
       QuicClientConnectionState* conn) = 0;


### PR DESCRIPTION
The reference is not passed down anymore, so warning about it is moot.