### PR TITLE
Properly link mvfst_codec_packet_number_cipher as a dependency of mvfst_fizz_handshake

### DIFF
--- a/quic/fizz/client/CMakeLists.txt
+++ b/quic/fizz/client/CMakeLists.txt
@@ -25,14 +25,12 @@ add_dependencies(
   mvfst_fizz_client
   mvfst_client
   mvfst_fizz_handshake
-  mvfst_codec_packet_number_cipher
 )
 
 target_link_libraries(
   mvfst_fizz_client PUBLIC
   mvfst_client
   mvfst_fizz_handshake
-  mvfst_codec_packet_number_cipher
 )
 
 file(

--- a/quic/fizz/handshake/CMakeLists.txt
+++ b/quic/fizz/handshake/CMakeLists.txt
@@ -26,12 +26,16 @@ target_compile_options(
 
 add_dependencies(
   mvfst_fizz_handshake
+  ${LIBFIZZ_LIBRARY}
   mvfst_handshake
+  mvfst_codec_packet_number_cipher
 )
 
 target_link_libraries(
   mvfst_fizz_handshake PUBLIC
   ${LIBFIZZ_LIBRARY}
+  mvfst_handshake
+  mvfst_codec_packet_number_cipher
 )
 
 file(


### PR DESCRIPTION
The dependency were incorrect, but happened to work anyways.