### PR TITLE
Make ServerHandshake's fields protected

### DIFF
--- a/quic/server/handshake/ServerHandshake.h
+++ b/quic/server/handshake/ServerHandshake.h
@@ -105,6 +105,13 @@ class ServerHandshake : public Handshake {
   virtual void writeNewSessionTicket(const AppToken& appToken);
 
   /**
+   * Returns a reference to the CryptoFactory used internaly.
+   */
+  virtual const CryptoFactory& getCryptoFactory() const {
+    return *cryptoFactory_;
+  }
+
+  /**
    * An edge triggered API to get the handshakeWriteCipher. Once you receive the
    * write cipher subsequent calls will return null.
    */
@@ -247,6 +254,7 @@ class ServerHandshake : public Handshake {
    */
   void processPendingEvents();
 
+ protected:
   fizz::server::State state_;
   fizz::server::ServerStateMachine machine_;
   QuicConnectionStateBase* conn_;

--- a/quic/server/state/ServerStateMachine.cpp
+++ b/quic/server/state/ServerStateMachine.cpp
@@ -634,7 +634,8 @@ void onServerReadDataFromOpen(
             conn.serverConnectionId.value(),
             initialDestinationConnectionId));
     conn.transportParametersEncoded = true;
-    CryptoFactory& cryptoFactory = *conn.serverHandshakeLayer->cryptoFactory_;
+    const CryptoFactory& cryptoFactory =
+        conn.serverHandshakeLayer->getCryptoFactory();
     conn.readCodec = std::make_unique<QuicReadCodec>(QuicNodeType::Server);
     conn.readCodec->setInitialReadCipher(cryptoFactory.getClientInitialCipher(
         initialDestinationConnectionId, version));


### PR DESCRIPTION
This will make migrating the fizz parts way easier.