### PR TITLE
Move CryptoFactory from SrverHandshake to FizzServerHandshake

### DIFF
--- a/quic/fizz/server/handshake/FizzServerHandshake.h
+++ b/quic/fizz/server/handshake/FizzServerHandshake.h
@@ -10,6 +10,8 @@
 
 #include <quic/server/handshake/ServerHandshake.h>
 
+#include <quic/fizz/handshake/FizzCryptoFactory.h>
+
 namespace quic {
 
 class FizzServerQuicHandshakeContext;
@@ -21,7 +23,17 @@ class FizzServerHandshake : public ServerHandshake {
       QuicServerConnectionState* conn,
       std::shared_ptr<FizzServerQuicHandshakeContext> fizzContext);
 
+  const CryptoFactory& getCryptoFactory() const override;
+
  private:
+  void initializeImpl(
+      std::shared_ptr<const fizz::server::FizzServerContext> context,
+      HandshakeCallback* callback,
+      std::unique_ptr<fizz::server::AppTokenValidator> validator) override;
+
+ private:
+  FizzCryptoFactory cryptoFactory_;
+
   std::shared_ptr<FizzServerQuicHandshakeContext> fizzContext_;
 };
 

--- a/quic/server/handshake/ServerHandshake.h
+++ b/quic/server/handshake/ServerHandshake.h
@@ -107,9 +107,7 @@ class ServerHandshake : public Handshake {
   /**
    * Returns a reference to the CryptoFactory used internaly.
    */
-  virtual const CryptoFactory& getCryptoFactory() const {
-    return *cryptoFactory_;
-  }
+  virtual const CryptoFactory& getCryptoFactory() const = 0;
 
   /**
    * An edge triggered API to get the handshakeWriteCipher. Once you receive the
@@ -294,7 +292,12 @@ class ServerHandshake : public Handshake {
 
   Phase phase_{Phase::Handshake};
 
-  std::shared_ptr<CryptoFactory> cryptoFactory_;
   std::shared_ptr<ServerTransportParametersExtension> transportParams_;
+
+ private:
+  virtual void initializeImpl(
+      std::shared_ptr<const fizz::server::FizzServerContext> context,
+      HandshakeCallback* callback,
+      std::unique_ptr<fizz::server::AppTokenValidator> validator) = 0;
 }; // namespace quic
 } // namespace quic


### PR DESCRIPTION
This is moving some fizz specific part of the server handshake in FizzServerHandshake, following a similar pattern as what was done for the client.

Depends on #161 and #160 