### PR TITLE
Pass FizzServerContext using FizzServerQuicHandshakeContext

### DIFF
--- a/quic/api/test/QuicBatchWriterTest.cpp
+++ b/quic/api/test/QuicBatchWriterTest.cpp
@@ -27,7 +27,7 @@ constexpr const auto kNumLoops = 10;
 struct QuicBatchWriterTest : public ::testing::Test,
                              public ::testing::WithParamInterface<bool> {
   QuicBatchWriterTest()
-      : conn_(std::make_shared<FizzServerQuicHandshakeContext>()) {}
+      : conn_(FizzServerQuicHandshakeContext::Builder().build()) {}
 
  protected:
   QuicServerConnectionState conn_;

--- a/quic/api/test/QuicPacketSchedulerTest.cpp
+++ b/quic/api/test/QuicPacketSchedulerTest.cpp
@@ -186,7 +186,7 @@ TEST_F(QuicPacketSchedulerTest, PaddingUpToWrapperSize) {
 
 TEST_F(QuicPacketSchedulerTest, CryptoServerInitialPadded) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto connId = getTestConnectionId();
   PacketNum nextPacketNum = getNextPacketNum(conn, PacketNumberSpace::Initial);
   LongHeader longHeader1(
@@ -219,7 +219,7 @@ TEST_F(QuicPacketSchedulerTest, CryptoServerInitialPadded) {
 
 TEST_F(QuicPacketSchedulerTest, PadTwoInitialPackets) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto connId = getTestConnectionId();
   PacketNum nextPacketNum = getNextPacketNum(conn, PacketNumberSpace::Initial);
   LongHeader longHeader1(
@@ -303,7 +303,7 @@ TEST_F(QuicPacketSchedulerTest, CryptoPaddingRetransmissionClientInitial) {
 
 TEST_F(QuicPacketSchedulerTest, CryptoSchedulerOnlySingleLossFits) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto connId = getTestConnectionId();
   LongHeader longHeader(
       LongHeader::Types::Handshake,
@@ -367,7 +367,7 @@ TEST_F(QuicPacketSchedulerTest, CryptoWritePartialLossBuffer) {
 
 TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerExists) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   auto connId = getTestConnectionId();
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
@@ -390,7 +390,7 @@ TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerExists) {
 
 TEST_F(QuicPacketSchedulerTest, StreamFrameNoSpace) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   auto connId = getTestConnectionId();
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
@@ -414,7 +414,7 @@ TEST_F(QuicPacketSchedulerTest, StreamFrameNoSpace) {
 
 TEST_F(QuicPacketSchedulerTest, StreamFrameSchedulerStreamNotExists) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto connId = getTestConnectionId();
   StreamId nonExistentStream = 11;
 

--- a/quic/api/test/QuicTransportBaseTest.cpp
+++ b/quic/api/test/QuicTransportBaseTest.cpp
@@ -158,7 +158,7 @@ class TestQuicTransport
       : QuicTransportBase(evb, std::move(socket)) {
     setConnectionCallback(&cb);
     auto conn = std::make_unique<QuicServerConnectionState>(
-        std::make_shared<FizzServerQuicHandshakeContext>());
+        FizzServerQuicHandshakeContext::Builder().build());
     conn->clientConnectionId = ConnectionId({10, 9, 8, 7});
     conn->version = QuicVersion::MVFST;
     transportConn = conn.get();

--- a/quic/api/test/QuicTransportFunctionsTest.cpp
+++ b/quic/api/test/QuicTransportFunctionsTest.cpp
@@ -151,7 +151,7 @@ class QuicTransportFunctionsTest : public Test {
 
   std::unique_ptr<QuicServerConnectionState> createConn() {
     auto conn = std::make_unique<QuicServerConnectionState>(
-        std::make_shared<FizzServerQuicHandshakeContext>());
+        FizzServerQuicHandshakeContext::Builder().build());
     conn->serverConnectionId = getTestConnectionId();
     conn->clientConnectionId = getTestConnectionId();
     conn->version = QuicVersion::MVFST;
@@ -1549,7 +1549,7 @@ TEST_F(QuicTransportFunctionsTest, WriteProbingOldData) {
 
 TEST_F(QuicTransportFunctionsTest, WriteProbingCryptoData) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.serverConnectionId = getTestConnectionId();
   conn.clientConnectionId = getTestConnectionId();
   // writeCryptoDataProbesToSocketForTest writes Initial LongHeader, thus it

--- a/quic/api/test/TestQuicTransport.h
+++ b/quic/api/test/TestQuicTransport.h
@@ -26,7 +26,7 @@ class TestQuicTransport
       : QuicTransportBase(evb, std::move(socket)) {
     setConnectionCallback(&cb);
     conn_.reset(new QuicServerConnectionState(
-        std::make_shared<FizzServerQuicHandshakeContext>()));
+        FizzServerQuicHandshakeContext::Builder().build()));
     conn_->clientConnectionId = ConnectionId({9, 8, 7, 6});
     conn_->serverConnectionId = ConnectionId({1, 2, 3, 4});
     conn_->version = QuicVersion::MVFST;

--- a/quic/codec/test/QuicPacketRebuilderTest.cpp
+++ b/quic/codec/test/QuicPacketRebuilderTest.cpp
@@ -66,7 +66,7 @@ TEST_F(QuicPacketRebuilderTest, RebuildPacket) {
   ackBlocks.insert(200, 1000);
   AckFrameMetaData ackMeta(ackBlocks, 0us, kDefaultAckDelayExponent);
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
   auto streamId = stream->id;
@@ -204,7 +204,7 @@ TEST_F(QuicPacketRebuilderTest, RebuildAfterResetStream) {
       kDefaultUDPSendPacketLen, std::move(shortHeader1), 0 /* largestAcked */);
   regularBuilder1.encodePacketHeader();
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
   auto streamId = stream->id;
@@ -241,7 +241,7 @@ TEST_F(QuicPacketRebuilderTest, FinOnlyStreamRebuild) {
       kDefaultUDPSendPacketLen, std::move(shortHeader1), 0 /* largestAcked */);
   regularBuilder1.encodePacketHeader();
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
   auto streamId = stream->id;
@@ -286,7 +286,7 @@ TEST_F(QuicPacketRebuilderTest, RebuildDataStreamAndEmptyCryptoStream) {
   regularBuilder1.encodePacketHeader();
   // Get a bunch frames
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
   StreamId streamId = stream->id;
@@ -350,7 +350,7 @@ TEST_F(QuicPacketRebuilderTest, CannotRebuildEmptyCryptoStream) {
   regularBuilder1.encodePacketHeader();
   // Get a bunch frames
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   uint64_t cryptoOffset = 0;
   auto cryptoBuf = folly::IOBuf::copyBuffer("NewSessionTicket");
 
@@ -389,7 +389,7 @@ TEST_F(QuicPacketRebuilderTest, CannotRebuild) {
   ackBlocks.insert(200, 1000);
   AckFrameMetaData ackMeta(ackBlocks, 0us, kDefaultAckDelayExponent);
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(10);
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
   auto streamId = stream->id;
@@ -445,7 +445,7 @@ TEST_F(QuicPacketRebuilderTest, CloneCounter) {
   auto packet = std::move(regularBuilder).buildPacket();
   auto outstandingPacket = makeDummyOutstandingPacket(packet.packet, 1000);
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   ShortHeader shortHeader2(
       ProtectionType::KeyPhaseZero, getTestConnectionId(), 0);
   RegularQuicPacketBuilder regularBuilder2(
@@ -469,7 +469,7 @@ TEST_F(QuicPacketRebuilderTest, PurePingWontRebuild) {
   auto outstandingPacket = makeDummyOutstandingPacket(packet.packet, 50);
   EXPECT_EQ(1, outstandingPacket.packet.frames.size());
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   ShortHeader shortHeader2(
       ProtectionType::KeyPhaseZero, getTestConnectionId(), 0);
   RegularQuicPacketBuilder regularBuilder2(
@@ -483,7 +483,7 @@ TEST_F(QuicPacketRebuilderTest, PurePingWontRebuild) {
 
 TEST_F(QuicPacketRebuilderTest, LastStreamFrameSkipLen) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(100);
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
   auto streamId = stream->id;
@@ -558,7 +558,7 @@ TEST_F(QuicPacketRebuilderTest, LastStreamFrameSkipLen) {
 
 TEST_F(QuicPacketRebuilderTest, LastStreamFrameFinOnlyNotSkipLen) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.streamManager->setMaxLocalBidirectionalStreams(100);
   auto stream = conn.streamManager->createNextBidirectionalStream().value();
   auto streamId = stream->id;

--- a/quic/congestion_control/test/CopaTest.cpp
+++ b/quic/congestion_control/test/CopaTest.cpp
@@ -131,7 +131,7 @@ class CopaTest : public Test {
 
 TEST_F(CopaTest, TestWritableBytes) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.transportSettings.copaDeltaParam = 0.5;
   Copa copa(conn);
   EXPECT_TRUE(copa.inSlowStart());
@@ -148,7 +148,7 @@ TEST_F(CopaTest, TestWritableBytes) {
 
 TEST_F(CopaTest, PersistentCongestion) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.transportSettings.copaDeltaParam = 0.5;
   Copa copa(conn);
   auto qLogger = std::make_shared<FileQLogger>(VantagePoint::Client);
@@ -182,7 +182,7 @@ TEST_F(CopaTest, PersistentCongestion) {
 
 TEST_F(CopaTest, RemoveBytesWithoutLossOrAck) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.transportSettings.copaDeltaParam = 0.5;
   Copa copa(conn);
   auto qLogger = std::make_shared<FileQLogger>(VantagePoint::Client);
@@ -215,7 +215,7 @@ TEST_F(CopaTest, RemoveBytesWithoutLossOrAck) {
 
 TEST_F(CopaTest, TestSlowStartAck) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.transportSettings.copaDeltaParam = 0.5;
   Copa copa(conn);
   auto qLogger = std::make_shared<FileQLogger>(VantagePoint::Client);
@@ -318,7 +318,7 @@ TEST_F(CopaTest, TestSlowStartAck) {
 
 TEST_F(CopaTest, TestSteadyStateChanges) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.transportSettings.copaDeltaParam = 0.5;
   Copa copa(conn);
   auto now = Clock::now();
@@ -356,7 +356,7 @@ TEST_F(CopaTest, TestSteadyStateChanges) {
 
 TEST_F(CopaTest, TestVelocity) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.transportSettings.copaDeltaParam = 0.5;
   conn.transportSettings.pacingTimerTickInterval = 10ms;
   Copa copa(conn);
@@ -452,7 +452,7 @@ TEST_F(CopaTest, TestVelocity) {
 
 TEST_F(CopaTest, NoLargestAckedPacketNoCrash) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.transportSettings.copaDeltaParam = 0.5;
   Copa copa(conn);
   auto qLogger = std::make_shared<FileQLogger>(VantagePoint::Client);
@@ -474,7 +474,7 @@ TEST_F(CopaTest, NoLargestAckedPacketNoCrash) {
 
 TEST_F(CopaTest, PacketLossInvokesPacer) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.transportSettings.copaDeltaParam = 0.5;
   Copa copa(conn);
   auto mockPacer = std::make_unique<MockPacer>();

--- a/quic/congestion_control/test/NewRenoTest.cpp
+++ b/quic/congestion_control/test/NewRenoTest.cpp
@@ -60,7 +60,7 @@ createPacket(PacketNum packetNum, uint32_t size, TimePoint sendTime) {
 
 TEST_F(NewRenoTest, TestLoss) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   NewReno reno(conn);
   EXPECT_TRUE(reno.inSlowStart());
 
@@ -100,7 +100,7 @@ TEST_F(NewRenoTest, TestLoss) {
 
 TEST_F(NewRenoTest, SendMoreThanWritable) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   NewReno reno(conn);
   EXPECT_TRUE(reno.inSlowStart());
 
@@ -118,7 +118,7 @@ TEST_F(NewRenoTest, SendMoreThanWritable) {
 
 TEST_F(NewRenoTest, TestSlowStartAck) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   NewReno reno(conn);
   EXPECT_TRUE(reno.inSlowStart());
 
@@ -139,7 +139,7 @@ TEST_F(NewRenoTest, TestSlowStartAck) {
 
 TEST_F(NewRenoTest, TestSteadyStateAck) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   NewReno reno(conn);
   EXPECT_TRUE(reno.inSlowStart());
 
@@ -181,7 +181,7 @@ TEST_F(NewRenoTest, TestSteadyStateAck) {
 
 TEST_F(NewRenoTest, TestWritableBytes) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   NewReno reno(conn);
   EXPECT_TRUE(reno.inSlowStart());
 
@@ -197,7 +197,7 @@ TEST_F(NewRenoTest, TestWritableBytes) {
 
 TEST_F(NewRenoTest, PersistentCongestion) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   NewReno reno(conn);
   EXPECT_TRUE(reno.inSlowStart());
 
@@ -218,7 +218,7 @@ TEST_F(NewRenoTest, PersistentCongestion) {
 
 TEST_F(NewRenoTest, RemoveBytesWithoutLossOrAck) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   NewReno reno(conn);
   EXPECT_TRUE(reno.inSlowStart());
 

--- a/quic/fizz/server/handshake/FizzServerHandshake.cpp
+++ b/quic/fizz/server/handshake/FizzServerHandshake.cpp
@@ -9,6 +9,7 @@
 #include <quic/fizz/server/handshake/FizzServerHandshake.h>
 
 #include <quic/fizz/handshake/FizzBridge.h>
+#include <quic/fizz/server/handshake/FizzServerQuicHandshakeContext.h>
 
 // This is necessary for the conversion between QuicServerConnectionState and
 // QuicConnectionStateBase and can be removed once ServerHandshake accepts
@@ -23,16 +24,16 @@ FizzServerHandshake::FizzServerHandshake(
     : ServerHandshake(conn), fizzContext_(std::move(fizzContext)) {}
 
 void FizzServerHandshake::initializeImpl(
-    std::shared_ptr<const fizz::server::FizzServerContext> context,
     HandshakeCallback* callback,
     std::unique_ptr<fizz::server::AppTokenValidator> validator) {
-  auto ctx = std::make_shared<fizz::server::FizzServerContext>(*context);
-  ctx->setFactory(cryptoFactory_.getFizzFactory());
-  ctx->setSupportedCiphers({{fizz::CipherSuite::TLS_AES_128_GCM_SHA256}});
-  ctx->setVersionFallbackEnabled(false);
+  auto context = std::make_shared<fizz::server::FizzServerContext>(
+      *fizzContext_->getContext());
+  context->setFactory(cryptoFactory_.getFizzFactory());
+  context->setSupportedCiphers({{fizz::CipherSuite::TLS_AES_128_GCM_SHA256}});
+  context->setVersionFallbackEnabled(false);
   // Since Draft-17, client won't sent EOED
-  ctx->setOmitEarlyRecordLayer(true);
-  context_ = std::move(ctx);
+  context->setOmitEarlyRecordLayer(true);
+  context_ = std::move(context);
   callback_ = callback;
 
   if (validator) {

--- a/quic/fizz/server/handshake/FizzServerHandshake.h
+++ b/quic/fizz/server/handshake/FizzServerHandshake.h
@@ -26,7 +26,6 @@ class FizzServerHandshake : public ServerHandshake {
 
  private:
   void initializeImpl(
-      std::shared_ptr<const fizz::server::FizzServerContext> context,
       HandshakeCallback* callback,
       std::unique_ptr<fizz::server::AppTokenValidator> validator) override;
 

--- a/quic/fizz/server/handshake/FizzServerQuicHandshakeContext.cpp
+++ b/quic/fizz/server/handshake/FizzServerQuicHandshakeContext.cpp
@@ -12,10 +12,24 @@
 
 namespace quic {
 
+FizzServerQuicHandshakeContext::FizzServerQuicHandshakeContext(
+    std::shared_ptr<const fizz::server::FizzServerContext> context)
+    : context_(std::move(context)) {}
+
 std::unique_ptr<ServerHandshake>
 FizzServerQuicHandshakeContext::makeServerHandshake(
     QuicServerConnectionState* conn) {
   return std::make_unique<FizzServerHandshake>(conn, shared_from_this());
+}
+
+std::shared_ptr<FizzServerQuicHandshakeContext>
+FizzServerQuicHandshakeContext::Builder::build() {
+  if (!context_) {
+    context_ = std::make_shared<const fizz::server::FizzServerContext>();
+  }
+
+  return std::shared_ptr<FizzServerQuicHandshakeContext>(
+      new FizzServerQuicHandshakeContext(std::move(context_)));
 }
 
 } // namespace quic

--- a/quic/fizz/server/handshake/FizzServerQuicHandshakeContext.h
+++ b/quic/fizz/server/handshake/FizzServerQuicHandshakeContext.h
@@ -10,6 +10,8 @@
 
 #include <quic/server/handshake/ServerHandshakeFactory.h>
 
+#include <fizz/server/FizzServerContext.h>
+
 namespace quic {
 
 class FizzServerHandshake;
@@ -20,6 +22,40 @@ class FizzServerQuicHandshakeContext
  public:
   std::unique_ptr<ServerHandshake> makeServerHandshake(
       QuicServerConnectionState* conn) override;
+
+  const std::shared_ptr<const fizz::server::FizzServerContext>& getContext()
+      const {
+    return context_;
+  }
+
+ private:
+  /**
+   * We make the constructor private so that users have to use the Builder
+   * facility. This ensures that
+   *   - This will ALWAYS be managed by a shared_ptr, which the implementation
+   * expects.
+   *   - We can enforce that the internal state of FizzServerContext is always
+   * sane.
+   */
+  FizzServerQuicHandshakeContext(
+      std::shared_ptr<const fizz::server::FizzServerContext> context);
+
+  std::shared_ptr<const fizz::server::FizzServerContext> context_;
+
+ public:
+  class Builder {
+   public:
+    Builder& setFizzServerContext(
+        std::shared_ptr<const fizz::server::FizzServerContext> context) {
+      context_ = std::move(context);
+      return *this;
+    }
+
+    std::shared_ptr<FizzServerQuicHandshakeContext> build();
+
+   private:
+    std::shared_ptr<const fizz::server::FizzServerContext> context_;
+  };
 };
 
 } // namespace quic

--- a/quic/loss/test/QuicLossFunctionsTest.cpp
+++ b/quic/loss/test/QuicLossFunctionsTest.cpp
@@ -63,7 +63,7 @@ class QuicLossFunctionsTest : public TestWithParam<PacketNumberSpace> {
 
   std::unique_ptr<QuicServerConnectionState> createConn() {
     auto conn = std::make_unique<QuicServerConnectionState>(
-        std::make_shared<FizzServerQuicHandshakeContext>());
+        FizzServerQuicHandshakeContext::Builder().build());
     conn->clientConnectionId = getTestConnectionId();
     conn->version = QuicVersion::MVFST;
     conn->ackStates.initialAckState.nextPacketNum = 1;

--- a/quic/server/QuicServerTransport.cpp
+++ b/quic/server/QuicServerTransport.cpp
@@ -24,7 +24,9 @@ QuicServerTransport::QuicServerTransport(
     std::shared_ptr<const fizz::server::FizzServerContext> ctx)
     : QuicTransportBase(evb, std::move(sock)), ctx_(std::move(ctx)) {
   auto tempConn = std::make_unique<QuicServerConnectionState>(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder()
+          .setFizzServerContext(ctx_)
+          .build());
   tempConn->serverAddr = socket_->address();
   serverConn_ = tempConn.get();
   conn_.reset(tempConn.release());
@@ -141,7 +143,6 @@ void QuicServerTransport::accept() {
       conn_->flowControlState, conn_->transportSettings);
   serverConn_->serverHandshakeLayer->initialize(
       evb_,
-      ctx_,
       this,
       std::make_unique<DefaultAppTokenValidator>(serverConn_));
 }

--- a/quic/server/handshake/ServerHandshake.cpp
+++ b/quic/server/handshake/ServerHandshake.cpp
@@ -31,11 +31,10 @@ void ServerHandshake::accept(
 
 void ServerHandshake::initialize(
     folly::Executor* executor,
-    std::shared_ptr<const fizz::server::FizzServerContext> context,
     HandshakeCallback* callback,
     std::unique_ptr<fizz::server::AppTokenValidator> validator) {
   executor_ = executor;
-  initializeImpl(std::move(context), callback, std::move(validator));
+  initializeImpl(callback, std::move(validator));
 }
 
 void ServerHandshake::doHandshake(

--- a/quic/server/handshake/ServerHandshake.h
+++ b/quic/server/handshake/ServerHandshake.h
@@ -87,7 +87,6 @@ class ServerHandshake : public Handshake {
    */
   virtual void initialize(
       folly::Executor* executor,
-      std::shared_ptr<const fizz::server::FizzServerContext> context,
       HandshakeCallback* callback,
       std::unique_ptr<fizz::server::AppTokenValidator> validator = nullptr);
 
@@ -277,7 +276,6 @@ class ServerHandshake : public Handshake {
 
  private:
   virtual void initializeImpl(
-      std::shared_ptr<const fizz::server::FizzServerContext> context,
       HandshakeCallback* callback,
       std::unique_ptr<fizz::server::AppTokenValidator> validator) = 0;
 

--- a/quic/server/handshake/test/DefaultAppTokenValidatorTest.cpp
+++ b/quic/server/handshake/test/DefaultAppTokenValidatorTest.cpp
@@ -27,7 +27,7 @@ namespace test {
 
 TEST(DefaultAppTokenValidatorTest, TestValidParams) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
   conn.transportSettings.zeroRttSourceTokenMatchingPolicy =
@@ -56,7 +56,7 @@ TEST(
     DefaultAppTokenValidatorTest,
     TestValidUnequalParamsUpdateTransportSettings) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
   conn.transportSettings.zeroRttSourceTokenMatchingPolicy =
@@ -91,7 +91,7 @@ TEST(
 
 TEST(DefaultAppTokenValidatorTest, TestInvalidNullAppToken) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
 
@@ -107,7 +107,7 @@ TEST(DefaultAppTokenValidatorTest, TestInvalidNullAppToken) {
 
 TEST(DefaultAppTokenValidatorTest, TestInvalidEmptyTransportParams) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
 
@@ -126,7 +126,7 @@ TEST(DefaultAppTokenValidatorTest, TestInvalidEmptyTransportParams) {
 
 TEST(DefaultAppTokenValidatorTest, TestInvalidMissingParams) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
 
@@ -162,7 +162,7 @@ TEST(DefaultAppTokenValidatorTest, TestInvalidMissingParams) {
 
 TEST(DefaultAppTokenValidatorTest, TestInvalidRedundantParameter) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
 
@@ -192,7 +192,7 @@ TEST(DefaultAppTokenValidatorTest, TestInvalidRedundantParameter) {
 
 TEST(DefaultAppTokenValidatorTest, TestInvalidDecreasedInitialMaxStreamData) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
 
@@ -220,7 +220,7 @@ TEST(DefaultAppTokenValidatorTest, TestInvalidDecreasedInitialMaxStreamData) {
 
 TEST(DefaultAppTokenValidatorTest, TestChangedIdleTimeout) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
 
@@ -248,7 +248,7 @@ TEST(DefaultAppTokenValidatorTest, TestChangedIdleTimeout) {
 
 TEST(DefaultAppTokenValidatorTest, TestDecreasedInitialMaxStreams) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
 
@@ -276,7 +276,7 @@ TEST(DefaultAppTokenValidatorTest, TestDecreasedInitialMaxStreams) {
 
 TEST(DefaultAppTokenValidatorTest, TestInvalidAppParams) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.peerAddress = folly::SocketAddress("1.2.3.4", 443);
   conn.version = QuicVersion::MVFST;
 
@@ -304,7 +304,7 @@ TEST(DefaultAppTokenValidatorTest, TestInvalidAppParams) {
 class SourceAddressTokenTest : public Test {
  public:
   SourceAddressTokenTest()
-      : conn_(std::make_shared<FizzServerQuicHandshakeContext>()) {}
+      : conn_(FizzServerQuicHandshakeContext::Builder().build()) {}
 
   void SetUp() override {
     conn_.peerAddress = folly::SocketAddress("1.2.3.4", 443);

--- a/quic/server/test/ServerStateMachineTest.cpp
+++ b/quic/server/test/ServerStateMachineTest.cpp
@@ -30,7 +30,7 @@ void assertServerConnIdParamsEq(
 namespace test {
 TEST(ServerStateMachineTest, TestAddConnId) {
   QuicServerConnectionState serverState(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   ServerConnectionIdParams originalParams(12, 1, 37);
 
   auto algo = std::make_unique<DefaultConnectionIdAlgo>();
@@ -76,7 +76,7 @@ TEST(ServerStateMachineTest, TestAddConnId) {
 
 TEST(ServerStateMachineTest, TestCidRejected) {
   QuicServerConnectionState serverConn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   MockServerConnectionIdRejector mockRejector;
   ServerConnectionIdParams serverCidParams(10, 11, 12);
   MockConnectionIdAlgo mockCidAlgo;
@@ -108,7 +108,7 @@ TEST(ServerStateMachineTest, TestCidRejected) {
 
 TEST(ServerStateMachineTest, TestCidRejectedThenFail) {
   QuicServerConnectionState serverConn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   MockServerConnectionIdRejector mockRejector;
   ServerConnectionIdParams serverCidParams(10, 11, 12);
   MockConnectionIdAlgo mockCidAlgo;
@@ -136,7 +136,7 @@ TEST(ServerStateMachineTest, TestCidRejectedThenFail) {
 
 TEST(ServerStateMachineTest, TestCidRejectedGiveUp) {
   QuicServerConnectionState serverConn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   MockServerConnectionIdRejector mockRejector;
   ServerConnectionIdParams serverCidParams(10, 11, 12);
   MockConnectionIdAlgo mockCidAlgo;

--- a/quic/state/stream/test/StreamStateFunctionsTest.cpp
+++ b/quic/state/stream/test/StreamStateFunctionsTest.cpp
@@ -24,7 +24,7 @@ class StreamStateFunctionsTests : public Test {};
 
 TEST_F(StreamStateFunctionsTests, BasicResetTest) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId streamId = 0xbaad;
   QuicStreamState stream(streamId, conn);
   appendDataToReadBuffer(
@@ -58,7 +58,7 @@ TEST_F(StreamStateFunctionsTests, BasicResetTest) {
 
 TEST_F(StreamStateFunctionsTests, IsAllDataReceivedEmptyStream) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 3;
   QuicStreamState stream(id, conn);
   EXPECT_FALSE(isAllDataReceived(stream));
@@ -66,7 +66,7 @@ TEST_F(StreamStateFunctionsTests, IsAllDataReceivedEmptyStream) {
 
 TEST_F(StreamStateFunctionsTests, IsAllDataReceivedReadBufferHasHole) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 3;
   QuicStreamState stream(id, conn);
   stream.currentReadOffset = 100;
@@ -79,7 +79,7 @@ TEST_F(StreamStateFunctionsTests, IsAllDataReceivedReadBufferHasHole) {
 
 TEST_F(StreamStateFunctionsTests, IsAllDataReceivedReadBufferNoHoleNoFin) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 3;
   QuicStreamState stream(id, conn);
   stream.currentReadOffset = 100;
@@ -91,7 +91,7 @@ TEST_F(StreamStateFunctionsTests, IsAllDataReceivedReadBufferNoHoleNoFin) {
 
 TEST_F(StreamStateFunctionsTests, IsAllDataReceivedReadBufferEmptyBufferFin) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 3;
   QuicStreamState stream(id, conn);
   stream.currentReadOffset = 100;
@@ -102,7 +102,7 @@ TEST_F(StreamStateFunctionsTests, IsAllDataReceivedReadBufferEmptyBufferFin) {
 
 TEST_F(StreamStateFunctionsTests, IsAllDataReceivedReadBufferBufferFin) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 3;
   QuicStreamState stream(id, conn);
   stream.currentReadOffset = 100;
@@ -115,7 +115,7 @@ TEST_F(StreamStateFunctionsTests, IsAllDataReceivedReadBufferBufferFin) {
 
 TEST_F(StreamStateFunctionsTests, IsAllDataReceivedMultipleStreamDataNoHole) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 3;
   QuicStreamState stream(id, conn);
   stream.currentReadOffset = 100;
@@ -132,7 +132,7 @@ TEST_F(StreamStateFunctionsTests, IsAllDataReceivedMultipleStreamDataNoHole) {
 
 TEST_F(StreamStateFunctionsTests, IsAllDataReceivedMultipleStreamDataHasHole) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 3;
   QuicStreamState stream(id, conn);
   stream.currentReadOffset = 100;
@@ -149,7 +149,7 @@ TEST_F(StreamStateFunctionsTests, IsAllDataReceivedMultipleStreamDataHasHole) {
 
 TEST_F(StreamStateFunctionsTests, IsAllDataReceivedAllDataRead) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 3;
   QuicStreamState stream(id, conn);
   stream.currentReadOffset = 101;
@@ -159,7 +159,7 @@ TEST_F(StreamStateFunctionsTests, IsAllDataReceivedAllDataRead) {
 
 TEST_F(StreamStateFunctionsTests, SendReset) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 1;
   QuicStreamState stream(id, conn);
   writeDataToQuicStream(stream, folly::IOBuf::copyBuffer("hello"), true);
@@ -175,7 +175,7 @@ TEST_F(StreamStateFunctionsTests, SendReset) {
 
 TEST_F(StreamStateFunctionsTests, ResetNoFlowControlGenerated) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 1;
   QuicStreamState stream(id, conn);
   writeDataToQuicStream(stream, folly::IOBuf::copyBuffer("hello"), true);
@@ -199,7 +199,7 @@ TEST_F(StreamStateFunctionsTests, ResetNoFlowControlGenerated) {
 
 TEST_F(StreamStateFunctionsTests, ResetFlowControlGenerated) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto qLogger = std::make_shared<FileQLogger>(VantagePoint::Client);
   conn.qLogger = qLogger;
 
@@ -235,7 +235,7 @@ TEST_F(StreamStateFunctionsTests, ResetFlowControlGenerated) {
 
 TEST_F(StreamStateFunctionsTests, ResetOffsetNotMatch) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 1;
   QuicStreamState stream(id, conn);
   RstStreamFrame rst(id, GenericApplicationErrorCode::UNKNOWN, 10);
@@ -249,7 +249,7 @@ TEST_F(StreamStateFunctionsTests, ResetOffsetNotMatch) {
 
 TEST_F(StreamStateFunctionsTests, ResetOffsetLessThanMaxObserved) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 1;
   QuicStreamState stream(id, conn);
   RstStreamFrame rst(id, GenericApplicationErrorCode::UNKNOWN, 30);
@@ -262,7 +262,7 @@ TEST_F(StreamStateFunctionsTests, ResetOffsetLessThanMaxObserved) {
 
 TEST_F(StreamStateFunctionsTests, ResetOffsetGreaterThanStreamFlowControl) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 1;
   QuicStreamState stream(id, conn);
   RstStreamFrame rst(id, GenericApplicationErrorCode::UNKNOWN, 200);
@@ -275,7 +275,7 @@ TEST_F(StreamStateFunctionsTests, ResetOffsetGreaterThanStreamFlowControl) {
 
 TEST_F(StreamStateFunctionsTests, ResetOffsetGreaterThanConnFlowControl) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 1;
   QuicStreamState stream(id, conn);
   RstStreamFrame rst(id, GenericApplicationErrorCode::UNKNOWN, 200);
@@ -295,7 +295,7 @@ TEST_F(StreamStateFunctionsTests, ResetOffsetGreaterThanConnFlowControl) {
 
 TEST_F(StreamStateFunctionsTests, ResetAfterReadingAllBytesTillFin) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId id = 1;
   QuicStreamState stream(id, conn);
   RstStreamFrame rst(id, GenericApplicationErrorCode::UNKNOWN, 100);

--- a/quic/state/stream/test/StreamStateMachineTest.cpp
+++ b/quic/state/stream/test/StreamStateMachineTest.cpp
@@ -33,7 +33,7 @@ void verifyStreamReset(
 
 std::unique_ptr<QuicServerConnectionState> createConn() {
   auto conn = std::make_unique<QuicServerConnectionState>(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn->clientConnectionId = getTestConnectionId();
   conn->version = QuicVersion::MVFST;
   conn->ackStates.initialAckState.nextPacketNum = 1;

--- a/quic/state/test/AckHandlersTest.cpp
+++ b/quic/state/test/AckHandlersTest.cpp
@@ -36,7 +36,7 @@ auto testLossHandler(std::vector<PacketNum>& lostPackets) -> decltype(auto) {
 
 TEST_P(AckHandlersTest, TestAckMultipleSequentialBlocks) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.lossState.reorderingThreshold = 85;
   auto mockCongestionController = std::make_unique<MockCongestionController>();
   auto rawCongestionController = mockCongestionController.get();
@@ -107,7 +107,7 @@ TEST_P(AckHandlersTest, TestAckMultipleSequentialBlocks) {
 
 TEST_P(AckHandlersTest, TestAckMultipleSequentialBlocksLoss) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.lossState.reorderingThreshold = 85;
   auto mockCongestionController = std::make_unique<MockCongestionController>();
   auto rawCongestionController = mockCongestionController.get();
@@ -244,7 +244,7 @@ TEST_P(AckHandlersTest, TestAckMultipleSequentialBlocksLoss) {
 
 TEST_P(AckHandlersTest, TestAckBlocksWithGaps) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.lossState.reorderingThreshold = 30;
   auto mockCongestionController = std::make_unique<MockCongestionController>();
   auto rawCongestionController = mockCongestionController.get();
@@ -342,7 +342,7 @@ TEST_P(AckHandlersTest, TestAckBlocksWithGaps) {
 
 TEST_P(AckHandlersTest, TestNonSequentialPacketNumbers) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.lossState.reorderingThreshold = 10;
   auto mockCongestionController = std::make_unique<MockCongestionController>();
   auto rawCongestionController = mockCongestionController.get();
@@ -436,7 +436,7 @@ TEST_P(AckHandlersTest, TestNonSequentialPacketNumbers) {
 
 TEST_P(AckHandlersTest, AckVisitorForAckTest) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.connectionTime = Clock::now();
   auto firstPacket = createNewPacket(100 /* packetNum */, GetParam());
   WriteAckFrame firstAckFrame;
@@ -508,7 +508,7 @@ TEST_P(AckHandlersTest, AckVisitorForAckTest) {
 
 TEST_P(AckHandlersTest, NoNewAckedPacket) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto mockController = std::make_unique<MockCongestionController>();
   auto rawController = mockController.get();
   conn.congestionController = std::move(mockController);
@@ -536,7 +536,7 @@ TEST_P(AckHandlersTest, NoNewAckedPacket) {
 
 TEST_P(AckHandlersTest, LossByAckedRecovered) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto mockController = std::make_unique<MockCongestionController>();
   conn.congestionController = std::move(mockController);
 
@@ -554,7 +554,7 @@ TEST_P(AckHandlersTest, LossByAckedRecovered) {
 
 TEST_P(AckHandlersTest, AckPacketNumDoesNotExist) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto mockController = std::make_unique<MockCongestionController>();
   conn.congestionController = std::move(mockController);
   // Get the time based loss detection out of the way
@@ -588,7 +588,7 @@ TEST_P(AckHandlersTest, AckPacketNumDoesNotExist) {
 
 TEST_P(AckHandlersTest, TestHandshakeCounterUpdate) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   StreamId stream = 1;
   for (PacketNum packetNum = 0; packetNum < 10; packetNum++) {
     auto regularPacket = createNewPacket(
@@ -647,7 +647,7 @@ TEST_P(AckHandlersTest, TestHandshakeCounterUpdate) {
 
 TEST_P(AckHandlersTest, PurgeAcks) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   WriteAckFrame ackFrame;
   ackFrame.ackBlocks.emplace_back(900, 1000);
   ackFrame.ackBlocks.emplace_back(500, 700);
@@ -666,7 +666,7 @@ TEST_P(AckHandlersTest, PurgeAcks) {
 
 TEST_P(AckHandlersTest, NoSkipAckVisitor) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto mockCongestionController = std::make_unique<MockCongestionController>();
   auto rawCongestionController = mockCongestionController.get();
   conn.congestionController = std::move(mockCongestionController);
@@ -708,7 +708,7 @@ TEST_P(AckHandlersTest, NoSkipAckVisitor) {
 
 TEST_P(AckHandlersTest, SkipAckVisitor) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto mockCongestionController = std::make_unique<MockCongestionController>();
   auto rawCongestionController = mockCongestionController.get();
   conn.congestionController = std::move(mockCongestionController);
@@ -756,7 +756,7 @@ TEST_P(AckHandlersTest, SkipAckVisitor) {
 
 TEST_P(AckHandlersTest, NoDoubleProcess) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.congestionController.reset();
 
   WriteStreamFrame frame(0, 0, 0, true);
@@ -822,7 +822,7 @@ TEST_P(AckHandlersTest, NoDoubleProcess) {
 
 TEST_P(AckHandlersTest, ClonedPacketsCounter) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.congestionController = nullptr;
   WriteStreamFrame frame(0, 0, 0, true);
   auto packetNum1 = conn.ackStates.appDataAckState.nextPacketNum;
@@ -870,7 +870,7 @@ TEST_P(AckHandlersTest, ClonedPacketsCounter) {
 
 TEST_P(AckHandlersTest, UpdateMaxAckDelay) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.congestionController = nullptr;
   conn.lossState.mrtt = 200us;
   PacketNum packetNum = 0;
@@ -899,7 +899,7 @@ TEST_P(AckHandlersTest, UpdateMaxAckDelay) {
 // Ack only acks packets aren't outstanding, but TimeReordering still finds loss
 TEST_P(AckHandlersTest, AckNotOutstandingButLoss) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto mockQLogger = std::make_shared<MockQLogger>(VantagePoint::Server);
   conn.qLogger = mockQLogger;
 
@@ -964,7 +964,7 @@ TEST_P(AckHandlersTest, AckNotOutstandingButLoss) {
 
 TEST_P(AckHandlersTest, UpdatePendingAckStates) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.congestionController = nullptr;
   conn.lossState.totalBytesSent = 2468;
   conn.lossState.totalBytesAcked = 1357;
@@ -1000,7 +1000,7 @@ TEST_P(AckHandlersTest, UpdatePendingAckStates) {
 
 TEST_P(AckHandlersTest, AckEventCreation) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto mockCongestionController = std::make_unique<MockCongestionController>();
   auto rawCongestionController = mockCongestionController.get();
   conn.congestionController = std::move(mockCongestionController);

--- a/quic/state/test/QPRFunctionsTest.cpp
+++ b/quic/state/test/QPRFunctionsTest.cpp
@@ -22,7 +22,7 @@ namespace test {
 class QPRFunctionsTest : public Test {
  public:
   QPRFunctionsTest()
-      : conn(std::make_shared<FizzServerQuicHandshakeContext>()) {}
+      : conn(FizzServerQuicHandshakeContext::Builder().build()) {}
 
   void SetUp() override {
     conn.flowControlState.peerAdvertisedInitialMaxStreamOffsetBidiLocal =

--- a/quic/state/test/QuicStateFunctionsTest.cpp
+++ b/quic/state/test/QuicStateFunctionsTest.cpp
@@ -57,7 +57,7 @@ class UpdateLargestReceivedPacketNumTest
 
 TEST_P(UpdateLargestReceivedPacketNumTest, ReceiveNew) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   getAckState(conn, GetParam()).largestReceivedPacketNum = 100;
   auto currentLargestReceived =
       *getAckState(conn, GetParam()).largestReceivedPacketNum;
@@ -71,7 +71,7 @@ TEST_P(UpdateLargestReceivedPacketNumTest, ReceiveNew) {
 
 TEST_P(UpdateLargestReceivedPacketNumTest, ReceiveOld) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   getAckState(conn, GetParam()).largestReceivedPacketNum = 100;
   auto currentLargestReceived =
       *getAckState(conn, GetParam()).largestReceivedPacketNum;
@@ -95,7 +95,7 @@ class UpdateAckStateTest : public TestWithParam<PacketNumberSpace> {};
 
 TEST_P(UpdateAckStateTest, TestUpdateAckState) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   PacketNum nextPacketNum = 0;
   auto& ackState = getAckState(conn, GetParam());
   updateAckState(conn, GetParam(), nextPacketNum++, true, false, Clock::now());
@@ -173,7 +173,7 @@ TEST_P(UpdateAckStateTest, TestUpdateAckState) {
 
 TEST_P(UpdateAckStateTest, TestUpdateAckStateFrequency) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.transportSettings.rxPacketsBeforeAckInitThreshold = 20;
   conn.transportSettings.rxPacketsBeforeAckBeforeInit = 2;
   conn.transportSettings.rxPacketsBeforeAckAfterInit = 10;
@@ -373,7 +373,7 @@ class QuicStateFunctionsTest : public TestWithParam<PacketNumberSpace> {};
 
 TEST_F(QuicStateFunctionsTest, RttCalculationNoAckDelay) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto rttSample = 1100us;
   updateRtt(conn, rttSample, 0us);
   EXPECT_EQ(1100, conn.lossState.srtt.count());
@@ -383,7 +383,7 @@ TEST_F(QuicStateFunctionsTest, RttCalculationNoAckDelay) {
 
 TEST_F(QuicStateFunctionsTest, RttCalculationWithAckDelay) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto rttSample = 1000us;
   updateRtt(conn, rttSample, 300us);
   EXPECT_EQ(700, conn.lossState.srtt.count());
@@ -395,7 +395,7 @@ TEST_F(QuicStateFunctionsTest, RttCalculationWithAckDelay) {
 
 TEST_F(QuicStateFunctionsTest, RttCalculationWithMrttAckDelay) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.lossState.mrtt = 100us;
   auto rttSample = 1000us;
   updateRtt(conn, rttSample, 300us);
@@ -408,7 +408,7 @@ TEST_F(QuicStateFunctionsTest, RttCalculationWithMrttAckDelay) {
 
 TEST_F(QuicStateFunctionsTest, RttCalculationIgnoreAckDelay) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   conn.lossState.mrtt = 700us;
   auto rttSample = 900us;
   updateRtt(conn, rttSample, 300us);
@@ -421,7 +421,7 @@ TEST_F(QuicStateFunctionsTest, RttCalculationIgnoreAckDelay) {
 
 TEST_F(QuicStateFunctionsTest, RttCalculationAckDelayLarger) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto rttSample = 10us;
   updateRtt(conn, rttSample, 300us);
   EXPECT_EQ(10, conn.lossState.srtt.count());
@@ -433,7 +433,7 @@ TEST_F(QuicStateFunctionsTest, RttCalculationAckDelayLarger) {
 
 TEST_F(QuicStateFunctionsTest, TestInvokeStreamStateMachineConnectionError) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   QuicStreamState stream(1, conn);
   RstStreamFrame rst(1, GenericApplicationErrorCode::UNKNOWN, 100);
   stream.finalReadOffset = 1024;
@@ -447,7 +447,7 @@ TEST_F(QuicStateFunctionsTest, TestInvokeStreamStateMachineConnectionError) {
 
 TEST_F(QuicStateFunctionsTest, InvokeResetDoesNotSendFlowControl) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   QuicStreamState stream(1, conn);
   RstStreamFrame rst(1, GenericApplicationErrorCode::UNKNOWN, 90);
   // this would normally trigger a flow control update.
@@ -466,7 +466,7 @@ TEST_F(QuicStateFunctionsTest, TestInvokeStreamStateMachineStreamError) {
   // We isolate invalid events on streams to affect only the streams. Is that
   // a good idea? We'll find out.
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   QuicStreamState stream(1, conn);
   RstStreamFrame rst(1, GenericApplicationErrorCode::UNKNOWN, 100);
   try {
@@ -481,7 +481,7 @@ TEST_F(QuicStateFunctionsTest, TestInvokeStreamStateMachineStreamError) {
 
 TEST_F(QuicStateFunctionsTest, UpdateMinRtt) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   auto qLogger = std::make_shared<FileQLogger>(VantagePoint::Server);
   conn.qLogger = qLogger;
 
@@ -522,7 +522,7 @@ TEST_F(QuicStateFunctionsTest, UpdateMinRtt) {
 
 TEST_F(QuicStateFunctionsTest, UpdateMaxAckDelay) {
   QuicServerConnectionState conn(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   EXPECT_EQ(0us, conn.lossState.maxAckDelay);
   auto rttSample = 100us;
 

--- a/quic/state/test/QuicStreamFunctionsTest.cpp
+++ b/quic/state/test/QuicStreamFunctionsTest.cpp
@@ -54,7 +54,7 @@ class QuicStreamFunctionsTest : public Test {
 class QuicServerStreamFunctionsTest : public Test {
  public:
   QuicServerStreamFunctionsTest()
-      : conn(std::make_shared<FizzServerQuicHandshakeContext>()) {}
+      : conn(FizzServerQuicHandshakeContext::Builder().build()) {}
 
   void SetUp() override {
     conn.flowControlState.peerAdvertisedInitialMaxStreamOffsetBidiLocal =
@@ -1107,7 +1107,7 @@ TEST_F(QuicStreamFunctionsTest, IsSendingStream) {
   QuicClientConnectionState clientState(
       FizzClientQuicHandshakeContext::Builder().build());
   QuicServerConnectionState serverState(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   QuicNodeType nodeType;
   StreamId id;
 
@@ -1136,7 +1136,7 @@ TEST_F(QuicStreamFunctionsTest, IsReceivingStream) {
   QuicClientConnectionState clientState(
       FizzClientQuicHandshakeContext::Builder().build());
   QuicServerConnectionState serverState(
-      std::make_shared<FizzServerQuicHandshakeContext>());
+      FizzServerQuicHandshakeContext::Builder().build());
   QuicNodeType nodeType;
   StreamId id;
 

--- a/quic/state/test/QuicStreamManagerTest.cpp
+++ b/quic/state/test/QuicStreamManagerTest.cpp
@@ -22,7 +22,7 @@ namespace test {
 class QuicStreamManagerTest : public Test {
  public:
   QuicStreamManagerTest()
-      : conn(std::make_shared<FizzServerQuicHandshakeContext>()) {}
+      : conn(FizzServerQuicHandshakeContext::Builder().build()) {}
   void SetUp() override {
     conn.flowControlState.peerAdvertisedInitialMaxStreamOffsetBidiLocal =
         kDefaultStreamWindowSize;


### PR DESCRIPTION
This remove one more fizz specific element from the common API

Depends on #162 