### PR TITLE
Remove ServerHandshake::getContext

### DIFF
--- a/quic/fizz/server/handshake/FizzServerHandshake.cpp
+++ b/quic/fizz/server/handshake/FizzServerHandshake.cpp
@@ -32,7 +32,7 @@ void FizzServerHandshake::initializeImpl(
   context->setVersionFallbackEnabled(false);
   // Since Draft-17, client won't sent EOED
   context->setOmitEarlyRecordLayer(true);
-  context_ = std::move(context);
+  state_.context() = std::move(context);
   callback_ = callback;
 
   if (validator) {
@@ -49,6 +49,15 @@ EncryptionLevel FizzServerHandshake::getReadRecordLayerEncryptionLevel() {
 
 const CryptoFactory& FizzServerHandshake::getCryptoFactory() const {
   return cryptoFactory_;
+}
+
+void FizzServerHandshake::processAccept() {
+  addProcessingActions(machine_.processAccept(
+      state_, executor_, state_.context(), transportParams_));
+}
+
+const fizz::server::FizzServerContext* FizzServerHandshake::getContext() const {
+  return state_.context();
 }
 
 } // namespace quic

--- a/quic/fizz/server/handshake/FizzServerHandshake.h
+++ b/quic/fizz/server/handshake/FizzServerHandshake.h
@@ -24,6 +24,13 @@ class FizzServerHandshake : public ServerHandshake {
 
   const CryptoFactory& getCryptoFactory() const override;
 
+  void processAccept() override;
+
+  /**
+   * Returns the context used by the ServerHandshake.
+   */
+  const fizz::server::FizzServerContext* getContext() const;
+
  private:
   void initializeImpl(
       HandshakeCallback* callback,

--- a/quic/server/handshake/ServerHandshake.cpp
+++ b/quic/server/handshake/ServerHandshake.cpp
@@ -23,10 +23,9 @@ void ServerHandshake::accept(
   SCOPE_EXIT {
     inHandshakeStack_ = false;
   };
-  transportParams_ = transportParams;
+  transportParams_ = std::move(transportParams);
   inHandshakeStack_ = true;
-  addProcessingActions(machine_.processAccept(
-      state_, executor_, context_, std::move(transportParams)));
+  processAccept();
 }
 
 void ServerHandshake::initialize(
@@ -175,11 +174,6 @@ bool ServerHandshake::isHandshakeDone() {
 
 const fizz::server::State& ServerHandshake::getState() const {
   return state_;
-}
-
-const std::shared_ptr<const fizz::server::FizzServerContext>
-ServerHandshake::getContext() const {
-  return context_;
 }
 
 const folly::Optional<std::string>& ServerHandshake::getApplicationProtocol()

--- a/quic/server/handshake/ServerHandshake.h
+++ b/quic/server/handshake/ServerHandshake.h
@@ -192,12 +192,6 @@ class ServerHandshake : public Handshake {
   const fizz::server::State& getState() const;
 
   /**
-   * Returns the context used by the ServerHandshake.
-   */
-  const std::shared_ptr<const fizz::server::FizzServerContext> getContext()
-      const;
-
-  /**
    * Retuns the negotiated ALPN from the handshake.
    */
   const folly::Optional<std::string>& getApplicationProtocol() const override;
@@ -239,7 +233,6 @@ class ServerHandshake : public Handshake {
   QuicConnectionStateBase* conn_;
   folly::DelayedDestruction::DestructorGuard actionGuard_;
   folly::Executor* executor_;
-  std::shared_ptr<const fizz::server::FizzServerContext> context_;
   using PendingEvent = fizz::WriteNewSessionTicket;
   std::deque<PendingEvent> pendingEvents_;
 
@@ -280,5 +273,7 @@ class ServerHandshake : public Handshake {
       std::unique_ptr<fizz::server::AppTokenValidator> validator) = 0;
 
   virtual EncryptionLevel getReadRecordLayerEncryptionLevel() = 0;
+  virtual void processAccept() = 0;
 }; // namespace quic
+
 } // namespace quic

--- a/quic/server/handshake/test/ServerHandshakeTest.cpp
+++ b/quic/server/handshake/test/ServerHandshakeTest.cpp
@@ -28,6 +28,7 @@
 #include <quic/fizz/client/handshake/FizzClientExtensions.h>
 #include <quic/fizz/handshake/FizzBridge.h>
 #include <quic/fizz/handshake/QuicFizzFactory.h>
+#include <quic/fizz/server/handshake/FizzServerHandshake.h>
 #include <quic/fizz/server/handshake/FizzServerQuicHandshakeContext.h>
 #include <quic/handshake/HandshakeLayer.h>
 #include <quic/server/handshake/AppToken.h>
@@ -836,9 +837,10 @@ TEST_F(ServerHandshakeZeroRttTest, TestResumption) {
 }
 
 TEST_F(ServerHandshakeZeroRttTest, TestRejectZeroRttNotEnabled) {
-  auto realServerCtx = handshake->getContext();
+  auto realServerCtx =
+      dynamic_cast<FizzServerHandshake*>(handshake)->getContext();
   auto nonConstServerCtx =
-      const_cast<fizz::server::FizzServerContext*>(realServerCtx.get());
+      const_cast<fizz::server::FizzServerContext*>(realServerCtx);
   nonConstServerCtx->setEarlyDataSettings(
       false, fizz::server::ClockSkewTolerance(), nullptr);
   EXPECT_CALL(*validator_, validate(_)).Times(0);


### PR DESCRIPTION
We can remove the reference to the context in the handshake and use `state_.context()` instead.

Depends on #165 