### PR TITLE
Move FailingAppTokenValidator to FizzServerHandshake.cpp

### DIFF
--- a/quic/common/test/TestUtils.cpp
+++ b/quic/common/test/TestUtils.cpp
@@ -14,6 +14,7 @@
 #include <quic/api/QuicTransportFunctions.h>
 #include <quic/codec/DefaultConnectionIdAlgo.h>
 #include <quic/fizz/handshake/QuicFizzFactory.h>
+#include <quic/fizz/server/handshake/AppToken.h>
 #include <quic/handshake/test/Mocks.h>
 #include <quic/server/handshake/StatelessResetGenerator.h>
 #include <quic/state/stream/StreamSendHandlers.h>

--- a/quic/fizz/server/handshake/AppToken.cpp
+++ b/quic/fizz/server/handshake/AppToken.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#include <quic/fizz/server/handshake/AppToken.h>
+
+#include <quic/fizz/handshake/FizzTransportParameters.h>
+
+#include <fizz/server/State.h>
+
+#include <vector>
+
+namespace quic {
+
+std::unique_ptr<folly::IOBuf> encodeAppToken(const AppToken& appToken) {
+  auto buf = folly::IOBuf::create(20);
+  folly::io::Appender appender(buf.get(), 20);
+  auto ext = encodeExtension(appToken.transportParams, QuicVersion::MVFST);
+  fizz::detail::write(ext, appender);
+  fizz::detail::writeVector<uint8_t>(appToken.sourceAddresses, appender);
+  fizz::detail::write(appToken.version, appender);
+  fizz::detail::writeBuf<uint16_t>(appToken.appParams, appender);
+  return buf;
+}
+
+folly::Optional<AppToken> decodeAppToken(const folly::IOBuf& buf) {
+  AppToken appToken;
+  folly::io::Cursor cursor(&buf);
+  std::vector<fizz::Extension> extensions;
+  fizz::Extension ext;
+  try {
+    fizz::detail::read(ext, cursor);
+    extensions.push_back(std::move(ext));
+    // TODO plumb version
+    appToken.transportParams =
+        *fizz::getTicketExtension(extensions, QuicVersion::MVFST);
+    fizz::detail::readVector<uint8_t>(appToken.sourceAddresses, cursor);
+    if (cursor.isAtEnd()) {
+      return appToken;
+    }
+    fizz::detail::read(appToken.version, cursor);
+    fizz::detail::readBuf<uint16_t>(appToken.appParams, cursor);
+  } catch (const std::exception&) {
+    return folly::none;
+  }
+  return appToken;
+}
+
+} // namespace quic

--- a/quic/fizz/server/handshake/AppToken.h
+++ b/quic/fizz/server/handshake/AppToken.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#pragma once
+
+#include <quic/server/handshake/AppToken.h>
+
+#include <fizz/record/Types.h>
+
+#include <folly/Optional.h>
+
+namespace quic {
+
+std::unique_ptr<folly::IOBuf> encodeAppToken(const AppToken& appToken);
+
+folly::Optional<AppToken> decodeAppToken(const folly::IOBuf& buf);
+
+} // namespace quic
+
+namespace fizz {
+namespace detail {
+
+template <>
+struct Reader<folly::IPAddress> {
+  template <class T>
+  size_t read(folly::IPAddress& ipAddress, folly::io::Cursor& cursor) {
+    std::unique_ptr<folly::IOBuf> sourceAddressBuf;
+    size_t len = readBuf<uint8_t>(sourceAddressBuf, cursor);
+    ipAddress = folly::IPAddress::fromBinary(sourceAddressBuf->coalesce());
+    return len;
+  }
+};
+
+template <>
+struct Writer<folly::IPAddress> {
+  template <class T>
+  void write(const folly::IPAddress& ipAddress, folly::io::Appender& out) {
+    DCHECK(!ipAddress.empty());
+    auto buf =
+        folly::IOBuf::wrapBuffer(ipAddress.bytes(), ipAddress.byteCount());
+    writeBuf<uint8_t>(buf, out);
+  }
+};
+
+template <>
+struct Sizer<folly::IPAddress> {
+  template <class T>
+  size_t getSize(const folly::IPAddress& ipAddress) {
+    return sizeof(uint8_t) + ipAddress.byteCount();
+  }
+};
+
+} // namespace detail
+} // namespace fizz

--- a/quic/fizz/server/handshake/FizzServerHandshake.cpp
+++ b/quic/fizz/server/handshake/FizzServerHandshake.cpp
@@ -11,11 +11,26 @@
 #include <quic/fizz/server/handshake/FizzServerQuicHandshakeContext.h>
 
 #include <fizz/protocol/Protocol.h>
+#include <fizz/server/State.h>
 
 // This is necessary for the conversion between QuicServerConnectionState and
 // QuicConnectionStateBase and can be removed once ServerHandshake accepts
 // QuicServerConnectionState.
 #include <quic/server/state/ServerStateMachine.h>
+
+namespace fizz {
+namespace server {
+struct ResumptionState;
+} // namespace server
+} // namespace fizz
+
+namespace {
+class FailingAppTokenValidator : public fizz::server::AppTokenValidator {
+  bool validate(const fizz::server::ResumptionState&) const override {
+    return false;
+  }
+};
+} // namespace
 
 namespace quic {
 

--- a/quic/server/CMakeLists.txt
+++ b/quic/server/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   state/ServerStateMachine.cpp
 
   # Fizz specific parts, will be split in its own lib eventually.
+  ../fizz/server/handshake/AppToken.cpp
   ../fizz/server/handshake/FizzServerQuicHandshakeContext.cpp
   ../fizz/server/handshake/FizzServerHandshake.cpp
 )

--- a/quic/server/handshake/DefaultAppTokenValidator.cpp
+++ b/quic/server/handshake/DefaultAppTokenValidator.cpp
@@ -11,6 +11,7 @@
 #include <quic/QuicConstants.h>
 #include <quic/api/QuicSocket.h>
 #include <quic/api/QuicTransportFunctions.h>
+#include <quic/fizz/server/handshake/AppToken.h>
 #include <quic/handshake/TransportParameters.h>
 #include <quic/server/state/ServerStateMachine.h>
 

--- a/quic/server/handshake/ServerHandshake.cpp
+++ b/quic/server/handshake/ServerHandshake.cpp
@@ -10,6 +10,7 @@
 
 #include <quic/fizz/handshake/FizzBridge.h>
 #include <quic/fizz/handshake/FizzCryptoFactory.h>
+#include <quic/fizz/server/handshake/AppToken.h>
 #include <quic/state/QuicStreamFunctions.h>
 
 namespace quic {

--- a/quic/server/handshake/test/AppTokenTest.cpp
+++ b/quic/server/handshake/test/AppTokenTest.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <quic/server/handshake/AppToken.h>
+#include <quic/fizz/server/handshake/AppToken.h>
 
 #include <quic/QuicConstants.h>
 #include <quic/server/state/ServerStateMachine.h>

--- a/quic/server/handshake/test/DefaultAppTokenValidatorTest.cpp
+++ b/quic/server/handshake/test/DefaultAppTokenValidatorTest.cpp
@@ -10,6 +10,7 @@
 
 #include <quic/QuicConstants.h>
 #include <quic/api/test/Mocks.h>
+#include <quic/fizz/server/handshake/AppToken.h>
 #include <quic/fizz/server/handshake/FizzServerQuicHandshakeContext.h>
 #include <quic/server/state/ServerStateMachine.h>
 

--- a/quic/server/handshake/test/ServerHandshakeTest.cpp
+++ b/quic/server/handshake/test/ServerHandshakeTest.cpp
@@ -28,6 +28,7 @@
 #include <quic/fizz/client/handshake/FizzClientExtensions.h>
 #include <quic/fizz/handshake/FizzBridge.h>
 #include <quic/fizz/handshake/QuicFizzFactory.h>
+#include <quic/fizz/server/handshake/AppToken.h>
 #include <quic/fizz/server/handshake/FizzServerHandshake.h>
 #include <quic/fizz/server/handshake/FizzServerQuicHandshakeContext.h>
 #include <quic/handshake/HandshakeLayer.h>


### PR DESCRIPTION
Also move encoding/decoding of the AppToken to be transmitted via fizz in its own file.