### PR TITLE
Adding packet rtt sampling to instrumentationObserver

### DIFF
--- a/quic/api/Observer.h
+++ b/quic/api/Observer.h
@@ -58,13 +58,16 @@ class InstrumentationObserver {
 
   struct PacketRTT {
     explicit PacketRTT(
-        std::chrono::microseconds rttsample,
-        std::chrono::microseconds ackdelay,
+        TimePoint rcvTimeIn,
+        std::chrono::microseconds rttSampleIn,
+        std::chrono::microseconds ackDelayIn,
         const quic::OutstandingPacket& pkt)
-        : rttSample(rttsample),
-          ackDelay(ackdelay),
+        : rcvTime(rcvTimeIn),
+          rttSample(rttSampleIn),
+          ackDelay(ackDelayIn),
           metadata(pkt.metadata),
           lastAckedPacketInfo(pkt.lastAckedPacketInfo) {}
+    TimePoint rcvTime;
     std::chrono::microseconds rttSample;
     std::chrono::microseconds ackDelay;
     const quic::OutstandingPacketMetadata metadata;
@@ -104,7 +107,7 @@ class InstrumentationObserver {
    *
    * @param packet   const reference to the packet with the RTT
    */
-  virtual void rttSampleGenerated(const struct PacketRTT& /* RTT sample */) {}
+  virtual void rttSampleGenerated(const PacketRTT& /* RTT sample */) {}
 };
 
 // Container for instrumentation observers.

--- a/quic/api/Observer.h
+++ b/quic/api/Observer.h
@@ -29,12 +29,13 @@ class InstrumentationObserver {
         const quic::OutstandingPacket& pkt)
         : lostByTimeout(lostbytimeout),
           lostByReorderThreshold(lostbyreorder),
-          metrics(pkt.metrics),
+          metadata(pkt.metadata),
           lastAckedPacketInfo(pkt.lastAckedPacketInfo) {}
     bool lostByTimeout{false};
     bool lostByReorderThreshold{false};
-    const quic::OutstandingPacketMetrics metrics;
-    const folly::Optional<OutstandingPacket::LastAckedPacketInfo> lastAckedPacketInfo;
+    const quic::OutstandingPacketMetadata metadata;
+    const folly::Optional<OutstandingPacket::LastAckedPacketInfo>
+        lastAckedPacketInfo;
   };
 
   struct ObserverLossEvent {
@@ -57,17 +58,18 @@ class InstrumentationObserver {
 
   struct PacketRTT {
     explicit PacketRTT(
-      std::chrono::microseconds rttsample,
-      std::chrono::microseconds ackdelay,
-      const quic::OutstandingPacket& pkt)
-      : rttSample(rttsample),
-        ackDelay(ackdelay),
-        metrics(pkt.metrics),
-        lastAckedPacketInfo(pkt.lastAckedPacketInfo) {}
+        std::chrono::microseconds rttsample,
+        std::chrono::microseconds ackdelay,
+        const quic::OutstandingPacket& pkt)
+        : rttSample(rttsample),
+          ackDelay(ackdelay),
+          metadata(pkt.metadata),
+          lastAckedPacketInfo(pkt.lastAckedPacketInfo) {}
     std::chrono::microseconds rttSample;
     std::chrono::microseconds ackDelay;
-    const quic::OutstandingPacketMetrics metrics;
-    const folly::Optional<OutstandingPacket::LastAckedPacketInfo> lastAckedPacketInfo;
+    const quic::OutstandingPacketMetadata metadata;
+    const folly::Optional<OutstandingPacket::LastAckedPacketInfo>
+        lastAckedPacketInfo;
   };
 
   virtual ~InstrumentationObserver() = default;
@@ -102,8 +104,7 @@ class InstrumentationObserver {
    *
    * @param packet   const reference to the packet with the RTT
    */
-  virtual void rttSampleGenerated(
-      const struct PacketRTT& /* RTT sample */) {}
+  virtual void rttSampleGenerated(const struct PacketRTT& /* RTT sample */) {}
 };
 
 // Container for instrumentation observers.

--- a/quic/api/QuicPacketScheduler.cpp
+++ b/quic/api/QuicPacketScheduler.cpp
@@ -613,7 +613,7 @@ SchedulingResult CloningScheduler::scheduleFramesForPacket(
     }
     // I think this only fail if udpSendPacketLen somehow shrinks in the middle
     // of a connection.
-    if (outstandingPacket.encodedSize > writableBytes + cipherOverhead_) {
+    if (outstandingPacket.metrics.encodedSize > writableBytes + cipherOverhead_) {
       continue;
     }
 

--- a/quic/api/QuicPacketScheduler.cpp
+++ b/quic/api/QuicPacketScheduler.cpp
@@ -613,7 +613,8 @@ SchedulingResult CloningScheduler::scheduleFramesForPacket(
     }
     // I think this only fail if udpSendPacketLen somehow shrinks in the middle
     // of a connection.
-    if (outstandingPacket.metrics.encodedSize > writableBytes + cipherOverhead_) {
+    if (outstandingPacket.metadata.encodedSize >
+        writableBytes + cipherOverhead_) {
       continue;
     }
 

--- a/quic/api/QuicTransportFunctions.cpp
+++ b/quic/api/QuicTransportFunctions.cpp
@@ -730,9 +730,9 @@ void updateConnection(
   }
   if (conn.pathValidationLimiter &&
       (conn.pendingEvents.pathChallenge || conn.outstandingPathValidation)) {
-    conn.pathValidationLimiter->onPacketSent(pkt.metrics.encodedSize);
+    conn.pathValidationLimiter->onPacketSent(pkt.metadata.encodedSize);
   }
-  if (pkt.metrics.isHandshake) {
+  if (pkt.metadata.isHandshake) {
     if (!pkt.associatedEvent) {
       if (packetNumberSpace == PacketNumberSpace::Initial) {
         ++conn.outstandings.initialPacketsCount;
@@ -741,9 +741,9 @@ void updateConnection(
         ++conn.outstandings.handshakePacketsCount;
       }
     }
-    conn.lossState.lastHandshakePacketSentTime = pkt.metrics.time;
+    conn.lossState.lastHandshakePacketSentTime = pkt.metadata.time;
   }
-  conn.lossState.lastRetransmittablePacketSentTime = pkt.metrics.time;
+  conn.lossState.lastRetransmittablePacketSentTime = pkt.metadata.time;
   if (pkt.associatedEvent) {
     ++conn.outstandings.clonedPacketsCount;
     ++conn.lossState.timeoutBasedRtxCount;

--- a/quic/api/QuicTransportFunctions.cpp
+++ b/quic/api/QuicTransportFunctions.cpp
@@ -687,7 +687,8 @@ void updateConnection(
       encodedSize,
       isHandshake,
       isD6DProbe,
-      conn.lossState.totalBytesSent);
+      conn.lossState.totalBytesSent,
+      conn.lossState.inflightBytes);
   if (isD6DProbe) {
     ++conn.d6d.outstandingProbes;
     return;
@@ -729,9 +730,9 @@ void updateConnection(
   }
   if (conn.pathValidationLimiter &&
       (conn.pendingEvents.pathChallenge || conn.outstandingPathValidation)) {
-    conn.pathValidationLimiter->onPacketSent(pkt.encodedSize);
+    conn.pathValidationLimiter->onPacketSent(pkt.metrics.encodedSize);
   }
-  if (pkt.isHandshake) {
+  if (pkt.metrics.isHandshake) {
     if (!pkt.associatedEvent) {
       if (packetNumberSpace == PacketNumberSpace::Initial) {
         ++conn.outstandings.initialPacketsCount;
@@ -740,9 +741,9 @@ void updateConnection(
         ++conn.outstandings.handshakePacketsCount;
       }
     }
-    conn.lossState.lastHandshakePacketSentTime = pkt.time;
+    conn.lossState.lastHandshakePacketSentTime = pkt.metrics.time;
   }
-  conn.lossState.lastRetransmittablePacketSentTime = pkt.time;
+  conn.lossState.lastRetransmittablePacketSentTime = pkt.metrics.time;
   if (pkt.associatedEvent) {
     ++conn.outstandings.clonedPacketsCount;
     ++conn.lossState.timeoutBasedRtxCount;

--- a/quic/api/test/Mocks.h
+++ b/quic/api/test/Mocks.h
@@ -332,6 +332,12 @@ class MockInstrumentationObserver : public InstrumentationObserver {
       ,
       packetLossDetected,
       void(const ObserverLossEvent&));
+  GMOCK_METHOD1_(
+      ,
+      noexcept,
+      ,
+      rttSampleGenerated,
+      void(const PacketRTT&));
 
   static auto getLossPacketMatcher(bool reorderLoss, bool timeoutLoss) {
     return AllOf(

--- a/quic/api/test/QuicPacketSchedulerTest.cpp
+++ b/quic/api/test/QuicPacketSchedulerTest.cpp
@@ -40,7 +40,7 @@ PacketNum addInitialOutstandingPacket(QuicConnectionStateBase& conn) {
       nextPacketNum,
       QuicVersion::QUIC_DRAFT);
   RegularQuicWritePacket packet(std::move(header));
-  conn.outstandings.packets.emplace_back(packet, Clock::now(), 0, true, 0);
+  conn.outstandings.packets.emplace_back(packet, Clock::now(), 0, true, 0, 0);
   conn.outstandings.handshakePacketsCount++;
   increaseNextPacketNum(conn, PacketNumberSpace::Handshake);
   return nextPacketNum;
@@ -58,7 +58,7 @@ PacketNum addHandshakeOutstandingPacket(QuicConnectionStateBase& conn) {
       nextPacketNum,
       QuicVersion::QUIC_DRAFT);
   RegularQuicWritePacket packet(std::move(header));
-  conn.outstandings.packets.emplace_back(packet, Clock::now(), 0, true, 0);
+  conn.outstandings.packets.emplace_back(packet, Clock::now(), 0, true, 0, 0);
   conn.outstandings.handshakePacketsCount++;
   increaseNextPacketNum(conn, PacketNumberSpace::Handshake);
   return nextPacketNum;
@@ -71,7 +71,7 @@ PacketNum addOutstandingPacket(QuicConnectionStateBase& conn) {
       conn.clientConnectionId.value_or(quic::test::getTestConnectionId()),
       nextPacketNum);
   RegularQuicWritePacket packet(std::move(header));
-  conn.outstandings.packets.emplace_back(packet, Clock::now(), 0, false, 0);
+  conn.outstandings.packets.emplace_back(packet, Clock::now(), 0, false, 0, 0);
   increaseNextPacketNum(conn, PacketNumberSpace::AppData);
   return nextPacketNum;
 }
@@ -1371,7 +1371,7 @@ TEST_F(
   conn.outstandings.packets.back().packet.frames.push_back(
       MaxDataFrame(conn.flowControlState.advertisedMaxOffset));
   // Lie about the encodedSize to let the Cloner skip it:
-  conn.outstandings.packets.back().encodedSize = kDefaultUDPSendPacketLen * 2;
+  conn.outstandings.packets.back().metrics.encodedSize = kDefaultUDPSendPacketLen * 2;
   EXPECT_TRUE(cloningScheduler.hasData());
 
   ASSERT_FALSE(noopScheduler.hasData());

--- a/quic/api/test/QuicPacketSchedulerTest.cpp
+++ b/quic/api/test/QuicPacketSchedulerTest.cpp
@@ -1371,7 +1371,8 @@ TEST_F(
   conn.outstandings.packets.back().packet.frames.push_back(
       MaxDataFrame(conn.flowControlState.advertisedMaxOffset));
   // Lie about the encodedSize to let the Cloner skip it:
-  conn.outstandings.packets.back().metrics.encodedSize = kDefaultUDPSendPacketLen * 2;
+  conn.outstandings.packets.back().metadata.encodedSize =
+      kDefaultUDPSendPacketLen * 2;
   EXPECT_TRUE(cloningScheduler.hasData());
 
   ASSERT_FALSE(noopScheduler.hasData());

--- a/quic/api/test/QuicTransportFunctionsTest.cpp
+++ b/quic/api/test/QuicTransportFunctionsTest.cpp
@@ -367,7 +367,7 @@ TEST_F(QuicTransportFunctionsTest, TestUpdateConnectionD6DNotConsumeSendPing) {
   conn->d6d.lastProbe = QuicConnectionStateBase::D6DProbePacket(packetNum, 50);
   updateConnection(*conn, folly::none, packet.packet, Clock::now(), 50);
   EXPECT_EQ(1, conn->outstandings.packets.size());
-  EXPECT_TRUE(conn->outstandings.packets.front().metrics.isD6DProbe);
+  EXPECT_TRUE(conn->outstandings.packets.front().metadata.isD6DProbe);
   EXPECT_EQ(1, conn->d6d.outstandingProbes);
   // sendPing should still be active since d6d probe should be "hidden" from
   // application
@@ -959,7 +959,7 @@ TEST_F(QuicTransportFunctionsTest, TestUpdateConnectionWithBytesStats) {
   EXPECT_EQ(
       13579 + 555,
       getFirstOutstandingPacket(*conn, PacketNumberSpace::Handshake)
-          ->metrics.totalBytesSent);
+          ->metadata.totalBytesSent);
   EXPECT_TRUE(getFirstOutstandingPacket(*conn, PacketNumberSpace::Handshake)
                   ->lastAckedPacketInfo.has_value());
   EXPECT_EQ(
@@ -1025,10 +1025,12 @@ TEST_F(QuicTransportFunctionsTest, TestUpdateConnectionWithCloneResult) {
   EXPECT_EQ(frame->maximumData, maxDataAmt);
   EXPECT_EQ(
       futureMoment,
-      getLastOutstandingPacket(*conn, PacketNumberSpace::AppData)->metrics.time);
+      getLastOutstandingPacket(*conn, PacketNumberSpace::AppData)
+          ->metadata.time);
   EXPECT_EQ(
       1500,
-      getLastOutstandingPacket(*conn, PacketNumberSpace::AppData)->metrics.encodedSize);
+      getLastOutstandingPacket(*conn, PacketNumberSpace::AppData)
+          ->metadata.encodedSize);
   EXPECT_EQ(
       event,
       *getLastOutstandingPacket(*conn, PacketNumberSpace::AppData)
@@ -1676,7 +1678,7 @@ TEST_F(QuicTransportFunctionsTest, TestCryptoWritingIsHandshakeInOutstanding) {
           conn->transportSettings.writeConnectionDataPacketsLimit));
   ASSERT_EQ(1, conn->outstandings.packets.size());
   EXPECT_TRUE(getFirstOutstandingPacket(*conn, PacketNumberSpace::Initial)
-                  ->metrics.isHandshake);
+                  ->metadata.isHandshake);
 }
 
 TEST_F(QuicTransportFunctionsTest, NoCryptoProbeWriteIfNoProbeCredit) {
@@ -1702,7 +1704,7 @@ TEST_F(QuicTransportFunctionsTest, NoCryptoProbeWriteIfNoProbeCredit) {
           conn->transportSettings.writeConnectionDataPacketsLimit));
   ASSERT_EQ(1, conn->outstandings.packets.size());
   EXPECT_TRUE(getFirstOutstandingPacket(*conn, PacketNumberSpace::Initial)
-                  ->metrics.isHandshake);
+                  ->metadata.isHandshake);
   ASSERT_EQ(1, cryptoStream->retransmissionBuffer.size());
   ASSERT_TRUE(cryptoStream->writeBuffer.empty());
 
@@ -2474,7 +2476,8 @@ TEST_F(QuicTransportFunctionsTest, WriteProbingWithInplaceBuilder) {
   ASSERT_FALSE(streamScheduler.hasPendingData());
 
   // The first packet has be a full packet
-  auto firstPacketSize = conn->outstandings.packets.front().metrics.encodedSize;
+  auto firstPacketSize =
+      conn->outstandings.packets.front().metadata.encodedSize;
   auto outstandingPacketsCount = conn->outstandings.packets.size();
   ASSERT_EQ(firstPacketSize, conn->udpSendPacketLen);
   EXPECT_CALL(mockSock, write(_, _))

--- a/quic/codec/test/QuicPacketRebuilderTest.cpp
+++ b/quic/codec/test/QuicPacketRebuilderTest.cpp
@@ -29,7 +29,7 @@ OutstandingPacket makeDummyOutstandingPacket(
     const RegularQuicWritePacket& writePacket,
     uint64_t totalBytesSentOnConnection) {
   OutstandingPacket packet(
-      writePacket, Clock::now(), 1000, false, totalBytesSentOnConnection);
+      writePacket, Clock::now(), 1000, false, totalBytesSentOnConnection, 0);
   return packet;
 }
 

--- a/quic/common/test/TestUtils.cpp
+++ b/quic/common/test/TestUtils.cpp
@@ -732,10 +732,10 @@ bool matchError(
 CongestionController::AckEvent::AckPacket makeAckPacketFromOutstandingPacket(
     OutstandingPacket outstandingPacket) {
   return CongestionController::AckEvent::AckPacket::Builder()
-      .setSentTime(outstandingPacket.metrics.time)
-      .setEncodedSize(outstandingPacket.metrics.encodedSize)
+      .setSentTime(outstandingPacket.metadata.time)
+      .setEncodedSize(outstandingPacket.metadata.encodedSize)
       .setLastAckedPacketInfo(std::move(outstandingPacket.lastAckedPacketInfo))
-      .setTotalBytesSentThen(outstandingPacket.metrics.totalBytesSent)
+      .setTotalBytesSentThen(outstandingPacket.metadata.totalBytesSent)
       .setAppLimited(outstandingPacket.isAppLimited)
       .build();
 }

--- a/quic/common/test/TestUtils.cpp
+++ b/quic/common/test/TestUtils.cpp
@@ -547,7 +547,8 @@ OutstandingPacket makeTestingWritePacket(
     PacketNum desiredPacketSeqNum,
     size_t desiredSize,
     uint64_t totalBytesSent,
-    TimePoint sentTime) {
+    TimePoint sentTime /* = Clock::now() */,
+    uint64_t inflightBytes /* = 0 */) {
   LongHeader longHeader(
       LongHeader::Types::ZeroRtt,
       getTestConnectionId(1),
@@ -556,7 +557,7 @@ OutstandingPacket makeTestingWritePacket(
       QuicVersion::MVFST);
   RegularQuicWritePacket packet(std::move(longHeader));
   return OutstandingPacket(
-      packet, sentTime, desiredSize, false, totalBytesSent);
+      packet, sentTime, desiredSize, false, totalBytesSent, inflightBytes);
 }
 
 CongestionController::AckEvent makeAck(
@@ -731,10 +732,10 @@ bool matchError(
 CongestionController::AckEvent::AckPacket makeAckPacketFromOutstandingPacket(
     OutstandingPacket outstandingPacket) {
   return CongestionController::AckEvent::AckPacket::Builder()
-      .setSentTime(outstandingPacket.time)
-      .setEncodedSize(outstandingPacket.encodedSize)
+      .setSentTime(outstandingPacket.metrics.time)
+      .setEncodedSize(outstandingPacket.metrics.encodedSize)
       .setLastAckedPacketInfo(std::move(outstandingPacket.lastAckedPacketInfo))
-      .setTotalBytesSentThen(outstandingPacket.totalBytesSent)
+      .setTotalBytesSentThen(outstandingPacket.metrics.totalBytesSent)
       .setAppLimited(outstandingPacket.isAppLimited)
       .build();
 }

--- a/quic/common/test/TestUtils.h
+++ b/quic/common/test/TestUtils.h
@@ -217,7 +217,8 @@ OutstandingPacket makeTestingWritePacket(
     PacketNum desiredPacketSeqNum,
     size_t desiredSize,
     uint64_t totalBytesSent,
-    TimePoint sentTime = Clock::now());
+    TimePoint sentTime = Clock::now(),
+    uint64_t inflightBytes = 0);
 
 // TODO: The way we setup packet sent, ack, loss in test cases can use some
 // major refactor.

--- a/quic/congestion_control/Bbr.cpp
+++ b/quic/congestion_control/Bbr.cpp
@@ -8,10 +8,10 @@
 
 // Copyright 2004-present Facebook.  All rights reserved.
 
-#include <quic/congestion_control/Bbr.h>
 #include <folly/Random.h>
 #include <quic/QuicConstants.h>
 #include <quic/common/TimeUtil.h>
+#include <quic/congestion_control/Bbr.h>
 #include <quic/congestion_control/CongestionControlFunctions.h>
 #include <quic/logging/QLoggerConstants.h>
 #include <quic/logging/QuicLogger.h>
@@ -116,9 +116,10 @@ void BbrCongestionController::onPacketSent(const OutstandingPacket& packet) {
   if (!conn_.lossState.inflightBytes && isAppLimited()) {
     exitingQuiescene_ = true;
   }
-  addAndCheckOverflow(conn_.lossState.inflightBytes, packet.metrics.encodedSize);
+  addAndCheckOverflow(
+      conn_.lossState.inflightBytes, packet.metadata.encodedSize);
   if (!ackAggregationStartTime_) {
-    ackAggregationStartTime_ = packet.metrics.time;
+    ackAggregationStartTime_ = packet.metadata.time;
   }
 }
 

--- a/quic/congestion_control/Bbr.cpp
+++ b/quic/congestion_control/Bbr.cpp
@@ -116,9 +116,9 @@ void BbrCongestionController::onPacketSent(const OutstandingPacket& packet) {
   if (!conn_.lossState.inflightBytes && isAppLimited()) {
     exitingQuiescene_ = true;
   }
-  addAndCheckOverflow(conn_.lossState.inflightBytes, packet.encodedSize);
+  addAndCheckOverflow(conn_.lossState.inflightBytes, packet.metrics.encodedSize);
   if (!ackAggregationStartTime_) {
-    ackAggregationStartTime_ = packet.time;
+    ackAggregationStartTime_ = packet.metrics.time;
   }
 }
 

--- a/quic/congestion_control/Copa.cpp
+++ b/quic/congestion_control/Copa.cpp
@@ -6,9 +6,9 @@
  *
  */
 
-#include <quic/congestion_control/Copa.h>
 #include <quic/common/TimeUtil.h>
 #include <quic/congestion_control/CongestionControlFunctions.h>
+#include <quic/congestion_control/Copa.h>
 #include <quic/logging/QLoggerConstants.h>
 #include <quic/logging/QuicLogger.h>
 
@@ -46,7 +46,8 @@ void Copa::onRemoveBytesFromInflight(uint64_t bytes) {
 }
 
 void Copa::onPacketSent(const OutstandingPacket& packet) {
-  addAndCheckOverflow(conn_.lossState.inflightBytes, packet.metrics.encodedSize);
+  addAndCheckOverflow(
+      conn_.lossState.inflightBytes, packet.metadata.encodedSize);
 
   VLOG(10) << __func__ << " writable=" << getWritableBytes()
            << " cwnd=" << cwndBytes_

--- a/quic/congestion_control/Copa.cpp
+++ b/quic/congestion_control/Copa.cpp
@@ -46,7 +46,7 @@ void Copa::onRemoveBytesFromInflight(uint64_t bytes) {
 }
 
 void Copa::onPacketSent(const OutstandingPacket& packet) {
-  addAndCheckOverflow(conn_.lossState.inflightBytes, packet.encodedSize);
+  addAndCheckOverflow(conn_.lossState.inflightBytes, packet.metrics.encodedSize);
 
   VLOG(10) << __func__ << " writable=" << getWritableBytes()
            << " cwnd=" << cwndBytes_

--- a/quic/congestion_control/NewReno.cpp
+++ b/quic/congestion_control/NewReno.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <quic/congestion_control/NewReno.h>
 #include <quic/congestion_control/CongestionControlFunctions.h>
+#include <quic/congestion_control/NewReno.h>
 #include <quic/logging/QLoggerConstants.h>
 
 namespace quic {
@@ -37,7 +37,8 @@ void NewReno::onRemoveBytesFromInflight(uint64_t bytes) {
 }
 
 void NewReno::onPacketSent(const OutstandingPacket& packet) {
-  addAndCheckOverflow(conn_.lossState.inflightBytes, packet.metrics.encodedSize);
+  addAndCheckOverflow(
+      conn_.lossState.inflightBytes, packet.metadata.encodedSize);
   VLOG(10) << __func__ << " writable=" << getWritableBytes()
            << " cwnd=" << cwndBytes_
            << " inflight=" << conn_.lossState.inflightBytes

--- a/quic/congestion_control/NewReno.cpp
+++ b/quic/congestion_control/NewReno.cpp
@@ -37,7 +37,7 @@ void NewReno::onRemoveBytesFromInflight(uint64_t bytes) {
 }
 
 void NewReno::onPacketSent(const OutstandingPacket& packet) {
-  addAndCheckOverflow(conn_.lossState.inflightBytes, packet.encodedSize);
+  addAndCheckOverflow(conn_.lossState.inflightBytes, packet.metrics.encodedSize);
   VLOG(10) << __func__ << " writable=" << getWritableBytes()
            << " cwnd=" << cwndBytes_
            << " inflight=" << conn_.lossState.inflightBytes

--- a/quic/congestion_control/QuicCubic.cpp
+++ b/quic/congestion_control/QuicCubic.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <quic/congestion_control/QuicCubic.h>
 #include <quic/congestion_control/CongestionControlFunctions.h>
+#include <quic/congestion_control/QuicCubic.h>
 #include <quic/logging/QLoggerConstants.h>
 #include <quic/state/QuicStateFunctions.h>
 
@@ -92,12 +92,12 @@ void Cubic::onPersistentCongestion() {
 
 void Cubic::onPacketSent(const OutstandingPacket& packet) {
   if (std::numeric_limits<uint64_t>::max() - conn_.lossState.inflightBytes <
-      packet.metrics.encodedSize) {
+      packet.metadata.encodedSize) {
     throw QuicInternalException(
         "Cubic: inflightBytes overflow",
         LocalErrorCode::INFLIGHT_BYTES_OVERFLOW);
   }
-  conn_.lossState.inflightBytes += packet.metrics.encodedSize;
+  conn_.lossState.inflightBytes += packet.metadata.encodedSize;
 }
 
 void Cubic::onPacketLoss(const LossEvent& loss) {

--- a/quic/congestion_control/QuicCubic.cpp
+++ b/quic/congestion_control/QuicCubic.cpp
@@ -92,12 +92,12 @@ void Cubic::onPersistentCongestion() {
 
 void Cubic::onPacketSent(const OutstandingPacket& packet) {
   if (std::numeric_limits<uint64_t>::max() - conn_.lossState.inflightBytes <
-      packet.encodedSize) {
+      packet.metrics.encodedSize) {
     throw QuicInternalException(
         "Cubic: inflightBytes overflow",
         LocalErrorCode::INFLIGHT_BYTES_OVERFLOW);
   }
-  conn_.lossState.inflightBytes += packet.encodedSize;
+  conn_.lossState.inflightBytes += packet.metrics.encodedSize;
 }
 
 void Cubic::onPacketLoss(const LossEvent& loss) {

--- a/quic/congestion_control/test/BbrBandwidthSamplerTest.cpp
+++ b/quic/congestion_control/test/BbrBandwidthSamplerTest.cpp
@@ -8,10 +8,10 @@
 
 // Copyright 2004-present Facebook.  All rights reserved.
 
-#include <quic/congestion_control/BbrBandwidthSampler.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
 #include <quic/common/test/TestUtils.h>
+#include <quic/congestion_control/BbrBandwidthSampler.h>
 
 using namespace testing;
 
@@ -70,7 +70,7 @@ TEST_F(BbrBandwidthSamplerTest, RateCalculation) {
         lastAckedPacketAckTime,
         0,
         0);
-    packet.time = ackTime - 50us;
+    packet.metadata.time = ackTime - 50us;
     ackEvent.ackedPackets.push_back(
         makeAckPacketFromOutstandingPacket(std::move(packet)));
   }
@@ -99,7 +99,7 @@ TEST_F(BbrBandwidthSamplerTest, RateCalculationWithAdjustedAckTime) {
         adjustedAckedPacketAckTime,
         0,
         0);
-    packet.time = ackTime - 50us;
+    packet.metadata.time = ackTime - 50us;
     ackEvent.ackedPackets.push_back(
         makeAckPacketFromOutstandingPacket(std::move(packet)));
   }
@@ -126,7 +126,7 @@ TEST_F(BbrBandwidthSamplerTest, SampleExpiration) {
       lastAckedPacketAckTime,
       1000,
       1000);
-  packet.time = ackTime - 50us;
+  packet.metadata.time = ackTime - 50us;
   ackEvent.ackedPackets.push_back(makeAckPacketFromOutstandingPacket(packet));
   sampler.onPacketAcked(ackEvent, 0);
   auto firstBandwidthSample = sampler.getBandwidth();
@@ -135,11 +135,11 @@ TEST_F(BbrBandwidthSamplerTest, SampleExpiration) {
   conn_.lossState.totalBytesAcked = 2000;
   auto packet2 = makeTestingWritePacket(pn, 500, 2500);
   packet2.lastAckedPacketInfo.emplace(
-      packet.time, ackTime, ackTime, 2000, 1000);
+      packet.metadata.time, ackTime, ackTime, 2000, 1000);
   auto ackTime2 = ackTime + 150us;
   CongestionController::AckEvent ackEvent2;
   ackEvent2.ackTime = ackTime2;
-  packet2.time = ackTime + 110us;
+  packet2.metadata.time = ackTime + 110us;
   ackEvent2.ackedPackets.push_back(makeAckPacketFromOutstandingPacket(packet2));
   sampler.onPacketAcked(ackEvent2, kBandwidthWindowLength / 4 + 1);
   auto secondBandwidthSample = sampler.getBandwidth();
@@ -149,11 +149,11 @@ TEST_F(BbrBandwidthSamplerTest, SampleExpiration) {
   conn_.lossState.totalBytesAcked = 2500;
   auto packet3 = makeTestingWritePacket(pn, 200, 2700);
   packet3.lastAckedPacketInfo.emplace(
-      packet2.time, ackTime2, ackTime2, 2500, 2000);
+      packet2.metadata.time, ackTime2, ackTime2, 2500, 2000);
   auto ackTime3 = ackTime + 250us;
   CongestionController::AckEvent ackEvent3;
   ackEvent3.ackTime = ackTime3;
-  packet3.time = ackTime + 210us;
+  packet3.metadata.time = ackTime + 210us;
   ackEvent3.ackedPackets.push_back(makeAckPacketFromOutstandingPacket(packet3));
   sampler.onPacketAcked(ackEvent3, kBandwidthWindowLength / 2 + 1);
   EXPECT_EQ(firstBandwidthSample, sampler.getBandwidth());
@@ -162,11 +162,11 @@ TEST_F(BbrBandwidthSamplerTest, SampleExpiration) {
   conn_.lossState.totalBytesAcked = 2700;
   auto packet4 = makeTestingWritePacket(pn, 100, 2800);
   packet4.lastAckedPacketInfo.emplace(
-      packet3.time, ackTime3, ackTime3, 2700, 2500);
+      packet3.metadata.time, ackTime3, ackTime3, 2700, 2500);
   auto ackTime4 = ackTime + 350us;
   CongestionController::AckEvent ackEvent4;
   ackEvent4.ackTime = ackTime4;
-  packet4.time = ackTime + 310us;
+  packet4.metadata.time = ackTime + 310us;
   ackEvent4.ackedPackets.push_back(makeAckPacketFromOutstandingPacket(packet4));
   sampler.onPacketAcked(ackEvent4, kBandwidthWindowLength + 1);
   // The bandwidth we got from packet1 has expired. Packet2 should have
@@ -188,7 +188,7 @@ TEST_F(BbrBandwidthSamplerTest, AppLimited) {
   ackEvent.largestAckedPacket = ++conn.lossState.largestSent.value();
   auto packet =
       makeTestingWritePacket(*ackEvent.largestAckedPacket, 1000, 1000);
-  ackEvent.largestAckedPacketSentTime = packet.time;
+  ackEvent.largestAckedPacketSentTime = packet.metadata.time;
   ackEvent.ackedPackets.push_back(
       makeAckPacketFromOutstandingPacket(std::move(packet)));
   sampler.onPacketAcked(ackEvent, 0);
@@ -224,7 +224,7 @@ TEST_F(BbrBandwidthSamplerTest, AppLimitedOutstandingPacket) {
       lastAckedPacketAckTime,
       0,
       0);
-  packet.time = ackTime - 50us;
+  packet.metadata.time = ackTime - 50us;
   ackEvent.ackedPackets.push_back(makeAckPacketFromOutstandingPacket(packet));
   // AppLimited packet, but sample is larger than current best
   sampler.onPacketAcked(ackEvent, 0);
@@ -234,8 +234,9 @@ TEST_F(BbrBandwidthSamplerTest, AppLimitedOutstandingPacket) {
   pn++;
   auto packet1 = makeTestingWritePacket(pn, 1000, 1000 + 1000 * pn);
   packet1.isAppLimited = true;
-  packet1.lastAckedPacketInfo.emplace(packet.time, ackTime, ackTime, 1000, 0);
-  packet1.time = ackTime + 500us;
+  packet1.lastAckedPacketInfo.emplace(
+      packet.metadata.time, ackTime, ackTime, 1000, 0);
+  packet1.metadata.time = ackTime + 500us;
   CongestionController::AckEvent ackEvent1;
   ackEvent1.ackedBytes = 1000;
   ackEvent1.ackTime = ackTime + 2000us;

--- a/quic/congestion_control/test/CMakeLists.txt
+++ b/quic/congestion_control/test/CMakeLists.txt
@@ -9,14 +9,19 @@ endif()
 
 quic_add_test(TARGET CongestionControllerTests
   SOURCES
+  BandwidthTest.cpp
+  BbrBandwidthSamplerTest.cpp
+  BbrRttSamplerTest.cpp
+  BbrTest.cpp
   CongestionControlFunctionsTest.cpp
+  CopaTest.cpp
   CubicHystartTest.cpp
   CubicRecoveryTest.cpp
   CubicStateTest.cpp
   CubicSteadyTest.cpp
   CubicTest.cpp
   NewRenoTest.cpp
-  CopaTest.cpp
+  PacerTest.cpp
   DEPENDS
   Folly::folly
   mvfst_cc_algo

--- a/quic/congestion_control/test/CopaTest.cpp
+++ b/quic/congestion_control/test/CopaTest.cpp
@@ -31,7 +31,7 @@ class CopaTest : public Test {
           ShortHeader(ProtectionType::KeyPhaseZero, connId, packetData.first));
       totalSentBytes += 10;
       loss.addLostPacket(OutstandingPacket(
-          std::move(packet), Clock::now(), 10, false, totalSentBytes));
+          std::move(packet), Clock::now(), 10, false, totalSentBytes, 0));
       loss.lostBytes = packetData.second;
     }
     loss.lostPackets = lostPackets.size();
@@ -39,12 +39,12 @@ class CopaTest : public Test {
   }
 
   OutstandingPacket
-  createPacket(PacketNum packetNum, uint32_t size, uint64_t totalSent) {
+  createPacket(PacketNum packetNum, uint32_t size, uint64_t totalSent, uint64_t inflight = 0) {
     auto connId = getTestConnectionId();
     RegularQuicWritePacket packet(
         ShortHeader(ProtectionType::KeyPhaseZero, connId, packetNum));
     return OutstandingPacket(
-        std::move(packet), Clock::now(), size, false, totalSent);
+        std::move(packet), Clock::now(), size, false, totalSent, inflight);
   }
 
   CongestionController::AckEvent createAckEvent(

--- a/quic/congestion_control/test/CubicHystartTest.cpp
+++ b/quic/congestion_control/test/CubicHystartTest.cpp
@@ -30,7 +30,7 @@ TEST_F(CubicHystartTest, SendAndAck) {
   auto packet = makeTestingWritePacket(0, 1000, 1000);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet.metrics.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet.metadata.time), folly::none);
 
   EXPECT_EQ(initCwnd + 1000, cubic.getWritableBytes());
   EXPECT_EQ(CubicStates::Hystart, cubic.state());
@@ -47,7 +47,7 @@ TEST_F(CubicHystartTest, CwndLargerThanSSThresh) {
   auto packet = makeTestingWritePacket(0, 1000, 1000);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet.metrics.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet.metadata.time), folly::none);
   EXPECT_EQ(initCwnd + 1000, cubic.getWritableBytes());
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 }
@@ -67,7 +67,7 @@ TEST_F(CubicHystartTest, NoDelayIncrease) {
   auto packet = makeTestingWritePacket(0, 1000, 1000, realNow);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, realNow + 2us, packet.metrics.time), folly::none);
+      makeAck(0, 1000, realNow + 2us, packet.metadata.time), folly::none);
   EXPECT_EQ(initCwnd + 1000, cubic.getWritableBytes());
   EXPECT_EQ(CubicStates::Hystart, cubic.state());
 }
@@ -92,7 +92,10 @@ TEST_F(CubicHystartTest, AckTrain) {
   // Packet 0 is acked:
   cubic.onPacketAckOrLoss(
       makeAck(
-          0, kLowSsthreshInMss * conn.udpSendPacketLen, realNow, packet0.metrics.time),
+          0,
+          kLowSsthreshInMss * conn.udpSendPacketLen,
+          realNow,
+          packet0.metadata.time),
       folly::none);
   // Packet 1 is acked:
   cubic.onPacketAckOrLoss(
@@ -100,7 +103,7 @@ TEST_F(CubicHystartTest, AckTrain) {
           1,
           kLowSsthreshInMss * conn.udpSendPacketLen,
           realNow + 2us,
-          packet1.metrics.time),
+          packet1.metadata.time),
       folly::none);
   EXPECT_EQ(
       initCwnd + kLowSsthreshInMss * conn.udpSendPacketLen * 2,
@@ -123,7 +126,7 @@ TEST_F(CubicHystartTest, NoAckTrainNoDelayIncrease) {
   auto packet = makeTestingWritePacket(0, 1000, 1000, realNow);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, realNow + kAckCountingGap + 2us, packet.metrics.time),
+      makeAck(0, 1000, realNow + kAckCountingGap + 2us, packet.metadata.time),
       folly::none);
   EXPECT_EQ(initCwnd + 1000, cubic.getWritableBytes());
   EXPECT_EQ(CubicStates::Hystart, cubic.state());
@@ -142,7 +145,8 @@ TEST_F(CubicHystartTest, DelayIncrease) {
         makeTestingWritePacket(packetNum, fullSize, fullSize + totalSent);
     cubic.onPacketSent(packet);
     cubic.onPacketAckOrLoss(
-        makeAck(packetNum++, fullSize, Clock::now(), packet.metrics.time), folly::none);
+        makeAck(packetNum++, fullSize, Clock::now(), packet.metadata.time),
+        folly::none);
     totalSent += fullSize;
   }
 
@@ -170,10 +174,12 @@ TEST_F(CubicHystartTest, DelayIncrease) {
   auto ackTimeIncrease = 2us;
   ackTime += ackTimeIncrease;
   cubic.onPacketAckOrLoss(
-      makeAck(firstPacketNum, 1000, ackTime, packet0.metrics.time), folly::none);
+      makeAck(firstPacketNum, 1000, ackTime, packet0.metadata.time),
+      folly::none);
   ackTime += ackTimeIncrease;
   cubic.onPacketAckOrLoss(
-      makeAck(secondPacketNum, 1000, ackTime, packet1.metrics.time), folly::none);
+      makeAck(secondPacketNum, 1000, ackTime, packet1.metadata.time),
+      folly::none);
   auto estimatedRttEndTarget = Clock::now();
 
   auto packet2 = makeTestingWritePacket(
@@ -182,9 +188,9 @@ TEST_F(CubicHystartTest, DelayIncrease) {
   conn.lossState.largestSent = packetNum;
   cubic.onPacketSent(packet2);
   // This will end current RTT round and start a new one next time Ack happens:
-  ackTime = packet2.metrics.time + ackTimeIncrease;
+  ackTime = packet2.metadata.time + ackTimeIncrease;
   cubic.onPacketAckOrLoss(
-      makeAck(packetNum, 1000, ackTime, packet2.metrics.time), folly::none);
+      makeAck(packetNum, 1000, ackTime, packet2.metadata.time), folly::none);
   packetNum++;
   auto cwndEndRound = cubic.getWritableBytes();
 
@@ -199,7 +205,8 @@ TEST_F(CubicHystartTest, DelayIncrease) {
     cubic.onPacketSent(packet);
     totalSent += 1000;
     ackTime += ackTimeIncrease;
-    moreAcks.push_back(makeAck(1 + packetNum, 1000, ackTime, packet.metrics.time));
+    moreAcks.push_back(
+        makeAck(1 + packetNum, 1000, ackTime, packet.metadata.time));
     packetNum++;
   }
   for (auto& ack : moreAcks) {
@@ -214,7 +221,7 @@ TEST_F(CubicHystartTest, DelayIncrease) {
   totalSent += 1000;
   ackTime += ackTimeIncrease;
   cubic.onPacketAckOrLoss(
-      makeAck(packetNum, 1000, ackTime, packetEnd.metrics.time), folly::none);
+      makeAck(packetNum, 1000, ackTime, packetEnd.metadata.time), folly::none);
 
   EXPECT_EQ(cwndEndRound + 1000 * kAckSampling, cubic.getWritableBytes());
   EXPECT_EQ(CubicStates::Steady, cubic.state());
@@ -243,16 +250,19 @@ TEST_F(CubicHystartTest, DelayIncreaseCwndTooSmall) {
   auto ackTime = realNow;
   auto ackTimeIncrease = 2us;
   ackTime += ackTimeIncrease;
-  cubic.onPacketAckOrLoss(makeAck(0, 1, ackTime, packet0.metrics.time), folly::none);
+  cubic.onPacketAckOrLoss(
+      makeAck(0, 1, ackTime, packet0.metadata.time), folly::none);
   ackTime += ackTimeIncrease;
-  cubic.onPacketAckOrLoss(makeAck(1, 1, ackTime, packet1.metrics.time), folly::none);
+  cubic.onPacketAckOrLoss(
+      makeAck(1, 1, ackTime, packet1.metadata.time), folly::none);
 
   auto packet2 = makeTestingWritePacket(2, 10, 10 + totalSent, realNow);
   conn.lossState.largestSent = 2;
   cubic.onPacketSent(packet2);
   totalSent += 10;
   ackTime += ackTimeIncrease;
-  cubic.onPacketAckOrLoss(makeAck(2, 1, ackTime, packet2.metrics.time), folly::none);
+  cubic.onPacketAckOrLoss(
+      makeAck(2, 1, ackTime, packet2.metadata.time), folly::none);
   auto cwndEndRound = cubic.getWritableBytes();
 
   // New RTT round, give currSampledRtt a value larger than previous RTT:
@@ -263,7 +273,7 @@ TEST_F(CubicHystartTest, DelayIncreaseCwndTooSmall) {
     conn.lossState.largestSent = i + 3;
     auto packet = makeTestingWritePacket(i + 3, 1, 1 + totalSent, realNow);
     ackTime += ackTimeIncrease;
-    moreAcks.push_back(makeAck(i + 3, 1, ackTime, packet.metrics.time));
+    moreAcks.push_back(makeAck(i + 3, 1, ackTime, packet.metadata.time));
     cubic.onPacketSent(packet);
     totalSent += 1;
   }
@@ -279,7 +289,7 @@ TEST_F(CubicHystartTest, DelayIncreaseCwndTooSmall) {
   totalSent += 1;
   ackTime += ackTimeIncrease;
   cubic.onPacketAckOrLoss(
-      makeAck(kAckSampling, 1, ackTime, packetEnd.metrics.time), folly::none);
+      makeAck(kAckSampling, 1, ackTime, packetEnd.metadata.time), folly::none);
   auto expectedCwnd = cwndEndRound + 1 * kAckSampling;
   // Cwnd < kLowSsthresh, won't exit Hystart state:
   ASSERT_LT(expectedCwnd, kLowSsthreshInMss * conn.udpSendPacketLen);

--- a/quic/congestion_control/test/CubicRecoveryTest.cpp
+++ b/quic/congestion_control/test/CubicRecoveryTest.cpp
@@ -57,7 +57,7 @@ TEST_F(CubicRecoveryTest, LossBeforeRecovery) {
   cubic.onPacketSent(packet);
   totalSent += 1000;
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet.metrics.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet.metadata.time), folly::none);
   EXPECT_EQ(CubicStates::Hystart, cubic.state());
 
   // Send three packets, lose second immediately.
@@ -83,9 +83,9 @@ TEST_F(CubicRecoveryTest, LossBeforeRecovery) {
   totalSent += 1000;
   conn.lossState.largestSent = 4;
   cubic.onPacketAckOrLoss(
-      makeAck(3, 1000, Clock::now(), packet3.metrics.time), folly::none);
+      makeAck(3, 1000, Clock::now(), packet3.metadata.time), folly::none);
   cubic.onPacketAckOrLoss(
-      makeAck(4, 1000, Clock::now(), packet4.metrics.time), folly::none);
+      makeAck(4, 1000, Clock::now(), packet4.metadata.time), folly::none);
   auto cwndAfterRecovery = cubic.getCongestionWindow();
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 
@@ -105,7 +105,7 @@ TEST_F(CubicRecoveryTest, LossAfterRecovery) {
   auto packet = makeTestingWritePacket(0, 1000, 1000);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet.metrics.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet.metadata.time), folly::none);
   // Lose one packet.
   auto packet1 = makeTestingWritePacket(1, 1000, 2000);
   cubic.onPacketSent(packet1);
@@ -152,13 +152,13 @@ TEST_F(CubicRecoveryTest, AckNotLargestNotChangeCwnd) {
 
   // the the rest are acked:
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet1.metrics.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet1.metadata.time), folly::none);
   cubic.onPacketAckOrLoss(
-      makeAck(1, 1000, Clock::now(), packet2.metrics.time), folly::none);
+      makeAck(1, 1000, Clock::now(), packet2.metadata.time), folly::none);
   cubic.onPacketAckOrLoss(
-      makeAck(2, 1000, Clock::now(), packet3.metrics.time), folly::none);
+      makeAck(2, 1000, Clock::now(), packet3.metadata.time), folly::none);
   cubic.onPacketAckOrLoss(
-      makeAck(3, 1000, Clock::now(), packet4.metrics.time), folly::none);
+      makeAck(3, 1000, Clock::now(), packet4.metadata.time), folly::none);
 
   // Still in recovery:
   EXPECT_EQ(CubicStates::FastRecovery, cubic.state());

--- a/quic/congestion_control/test/CubicRecoveryTest.cpp
+++ b/quic/congestion_control/test/CubicRecoveryTest.cpp
@@ -57,7 +57,7 @@ TEST_F(CubicRecoveryTest, LossBeforeRecovery) {
   cubic.onPacketSent(packet);
   totalSent += 1000;
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet.metrics.time), folly::none);
   EXPECT_EQ(CubicStates::Hystart, cubic.state());
 
   // Send three packets, lose second immediately.
@@ -83,9 +83,9 @@ TEST_F(CubicRecoveryTest, LossBeforeRecovery) {
   totalSent += 1000;
   conn.lossState.largestSent = 4;
   cubic.onPacketAckOrLoss(
-      makeAck(3, 1000, Clock::now(), packet3.time), folly::none);
+      makeAck(3, 1000, Clock::now(), packet3.metrics.time), folly::none);
   cubic.onPacketAckOrLoss(
-      makeAck(4, 1000, Clock::now(), packet4.time), folly::none);
+      makeAck(4, 1000, Clock::now(), packet4.metrics.time), folly::none);
   auto cwndAfterRecovery = cubic.getCongestionWindow();
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 
@@ -105,7 +105,7 @@ TEST_F(CubicRecoveryTest, LossAfterRecovery) {
   auto packet = makeTestingWritePacket(0, 1000, 1000);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet.metrics.time), folly::none);
   // Lose one packet.
   auto packet1 = makeTestingWritePacket(1, 1000, 2000);
   cubic.onPacketSent(packet1);
@@ -152,13 +152,13 @@ TEST_F(CubicRecoveryTest, AckNotLargestNotChangeCwnd) {
 
   // the the rest are acked:
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet1.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet1.metrics.time), folly::none);
   cubic.onPacketAckOrLoss(
-      makeAck(1, 1000, Clock::now(), packet2.time), folly::none);
+      makeAck(1, 1000, Clock::now(), packet2.metrics.time), folly::none);
   cubic.onPacketAckOrLoss(
-      makeAck(2, 1000, Clock::now(), packet3.time), folly::none);
+      makeAck(2, 1000, Clock::now(), packet3.metrics.time), folly::none);
   cubic.onPacketAckOrLoss(
-      makeAck(3, 1000, Clock::now(), packet4.time), folly::none);
+      makeAck(3, 1000, Clock::now(), packet4.metrics.time), folly::none);
 
   // Still in recovery:
   EXPECT_EQ(CubicStates::FastRecovery, cubic.state());

--- a/quic/congestion_control/test/CubicStateTest.cpp
+++ b/quic/congestion_control/test/CubicStateTest.cpp
@@ -35,7 +35,7 @@ TEST_F(CubicStateTest, HystartAck) {
   auto packet = makeTestingWritePacket(0, 0, 0);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 0, Clock::now(), packet.metrics.time), folly::none);
+      makeAck(0, 0, Clock::now(), packet.metadata.time), folly::none);
   EXPECT_EQ(CubicStates::Hystart, cubic.state());
 }
 
@@ -54,7 +54,7 @@ TEST_F(CubicStateTest, FastRecoveryAck) {
   loss.addLostPacket(packet);
   cubic.onPacketAckOrLoss(folly::none, std::move(loss));
   cubic.onPacketAckOrLoss(
-      makeAck(2, 1000, Clock::now(), packet1.metrics.time), folly::none);
+      makeAck(2, 1000, Clock::now(), packet1.metadata.time), folly::none);
   EXPECT_EQ(CubicStates::FastRecovery, cubic.state());
 }
 
@@ -71,7 +71,7 @@ TEST_F(CubicStateTest, FastRecoveryAckToSteady) {
   auto packet1 = makeTestingWritePacket(1, 1, 2);
   cubic.onPacketSent(packet1);
   cubic.onPacketAckOrLoss(
-      makeAck(1, 1, Clock::now(), packet1.metrics.time), folly::none);
+      makeAck(1, 1, Clock::now(), packet1.metadata.time), folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 }
 
@@ -95,7 +95,7 @@ TEST_F(CubicStateTest, SteadyAck) {
   auto packet = makeTestingWritePacket(0, 0, 0);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 0, Clock::now(), packet.metrics.time), folly::none);
+      makeAck(0, 0, Clock::now(), packet.metadata.time), folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 }
 

--- a/quic/congestion_control/test/CubicStateTest.cpp
+++ b/quic/congestion_control/test/CubicStateTest.cpp
@@ -35,7 +35,7 @@ TEST_F(CubicStateTest, HystartAck) {
   auto packet = makeTestingWritePacket(0, 0, 0);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 0, Clock::now(), packet.time), folly::none);
+      makeAck(0, 0, Clock::now(), packet.metrics.time), folly::none);
   EXPECT_EQ(CubicStates::Hystart, cubic.state());
 }
 
@@ -54,7 +54,7 @@ TEST_F(CubicStateTest, FastRecoveryAck) {
   loss.addLostPacket(packet);
   cubic.onPacketAckOrLoss(folly::none, std::move(loss));
   cubic.onPacketAckOrLoss(
-      makeAck(2, 1000, Clock::now(), packet1.time), folly::none);
+      makeAck(2, 1000, Clock::now(), packet1.metrics.time), folly::none);
   EXPECT_EQ(CubicStates::FastRecovery, cubic.state());
 }
 
@@ -71,7 +71,7 @@ TEST_F(CubicStateTest, FastRecoveryAckToSteady) {
   auto packet1 = makeTestingWritePacket(1, 1, 2);
   cubic.onPacketSent(packet1);
   cubic.onPacketAckOrLoss(
-      makeAck(1, 1, Clock::now(), packet1.time), folly::none);
+      makeAck(1, 1, Clock::now(), packet1.metrics.time), folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 }
 
@@ -95,7 +95,7 @@ TEST_F(CubicStateTest, SteadyAck) {
   auto packet = makeTestingWritePacket(0, 0, 0);
   cubic.onPacketSent(packet);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 0, Clock::now(), packet.time), folly::none);
+      makeAck(0, 0, Clock::now(), packet.metrics.time), folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 }
 

--- a/quic/congestion_control/test/CubicSteadyTest.cpp
+++ b/quic/congestion_control/test/CubicSteadyTest.cpp
@@ -29,7 +29,7 @@ TEST_F(CubicSteadyTest, CubicReduction) {
   conn.lossState.largestSent = 0;
   cubic.onPacketSent(packet0);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet0.metrics.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet0.metadata.time), folly::none);
   EXPECT_EQ(3000, cubic.getWritableBytes());
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 

--- a/quic/congestion_control/test/CubicSteadyTest.cpp
+++ b/quic/congestion_control/test/CubicSteadyTest.cpp
@@ -29,7 +29,7 @@ TEST_F(CubicSteadyTest, CubicReduction) {
   conn.lossState.largestSent = 0;
   cubic.onPacketSent(packet0);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet0.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet0.metrics.time), folly::none);
   EXPECT_EQ(3000, cubic.getWritableBytes());
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 

--- a/quic/congestion_control/test/CubicTest.cpp
+++ b/quic/congestion_control/test/CubicTest.cpp
@@ -36,7 +36,7 @@ TEST_F(CubicTest, AckIncreaseWritable) {
 
   // Acking 50, now inflight become 50. Cwnd is init + 50
   cubic.onPacketAckOrLoss(
-      makeAck(0, 50, Clock::now(), packet.metrics.time), folly::none);
+      makeAck(0, 50, Clock::now(), packet.metadata.time), folly::none);
   EXPECT_EQ(initCwnd, cubic.getWritableBytes());
 }
 
@@ -63,7 +63,8 @@ TEST_F(CubicTest, PersistentCongestion) {
   auto packet2 = makeTestingWritePacket(1, initCwnd / 2, initCwnd / 2 + 1000);
   cubic.onPacketSent(packet2);
   cubic.onPacketAckOrLoss(
-      makeAck(1, initCwnd / 2, Clock::now(), packet2.metrics.time), folly::none);
+      makeAck(1, initCwnd / 2, Clock::now(), packet2.metadata.time),
+      folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 
   // Verify both lastMaxCwndBytes and lastReductionTime are also reset in
@@ -74,7 +75,7 @@ TEST_F(CubicTest, PersistentCongestion) {
   auto packet3 = makeTestingWritePacket(2, 3000, initCwnd / 2 + 1000 + 3000);
   cubic.onPacketSent(packet3);
   cubic.onPacketAckOrLoss(
-      makeAck(2, 3000, Clock::now(), packet3.metrics.time), folly::none);
+      makeAck(2, 3000, Clock::now(), packet3.metadata.time), folly::none);
 
   std::vector<int> indices =
       getQLogEventIndices(QLogEventType::CongestionMetricUpdate, qLogger);
@@ -125,7 +126,7 @@ TEST_F(CubicTest, CwndIncreaseAfterReduction) {
   conn.lossState.largestSent = 0;
   cubic.onPacketSent(packet0);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet0.metrics.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet0.metadata.time), folly::none);
   // Cwnd increased by 1000, inflight = 0:
   EXPECT_EQ(3000, cubic.getWritableBytes());
   EXPECT_EQ(CubicStates::Steady, cubic.state());
@@ -142,7 +143,7 @@ TEST_F(CubicTest, CwndIncreaseAfterReduction) {
   EXPECT_EQ(0, cubic.getWritableBytes());
 
   cubic.onPacketAckOrLoss(
-      makeAck(1, 1000, Clock::now(), packet1.metrics.time), folly::none);
+      makeAck(1, 1000, Clock::now(), packet1.metadata.time), folly::none);
   // Cwnd >= 3000, inflight = 2000:
   EXPECT_GE(cubic.getWritableBytes(), 1000);
   CongestionController::LossEvent loss;
@@ -152,7 +153,7 @@ TEST_F(CubicTest, CwndIncreaseAfterReduction) {
   EXPECT_GE(cubic.getWritableBytes(), 1400);
   // This won't bring state machine back to Steady since endOfRecovery = 3
   cubic.onPacketAckOrLoss(
-      makeAck(3, 1000, Clock::now(), packet3.metrics.time), folly::none);
+      makeAck(3, 1000, Clock::now(), packet3.metadata.time), folly::none);
   // Cwnd no change, inflight = 0:
   EXPECT_GE(cubic.getWritableBytes(), 2400);
   EXPECT_EQ(CubicStates::FastRecovery, cubic.state());
@@ -162,7 +163,7 @@ TEST_F(CubicTest, CwndIncreaseAfterReduction) {
   cubic.onPacketSent(packet4);
   // This will bring state machine back to steady
   cubic.onPacketAckOrLoss(
-      makeAck(4, 1000, Clock::now(), packet4.metrics.time), folly::none);
+      makeAck(4, 1000, Clock::now(), packet4.metadata.time), folly::none);
   EXPECT_GE(cubic.getWritableBytes(), 2400);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 
@@ -197,7 +198,8 @@ TEST_F(CubicTest, AppIdle) {
   auto packet1 = makeTestingWritePacket(1, 1000, 2000);
   cubic.onPacketSent(packet1);
   cubic.onPacketAckOrLoss(
-      makeAck(1, 1000, reductionTime + 1000ms, packet1.metrics.time), folly::none);
+      makeAck(1, 1000, reductionTime + 1000ms, packet1.metadata.time),
+      folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
   EXPECT_GT(cubic.getCongestionWindow(), cwnd);
   cwnd = cubic.getCongestionWindow();
@@ -207,7 +209,8 @@ TEST_F(CubicTest, AppIdle) {
   auto packet2 = makeTestingWritePacket(2, 1000, 3000);
   cubic.onPacketSent(packet2);
   cubic.onPacketAckOrLoss(
-      makeAck(2, 1000, reductionTime + 2000ms, packet2.metrics.time), folly::none);
+      makeAck(2, 1000, reductionTime + 2000ms, packet2.metadata.time),
+      folly::none);
   EXPECT_EQ(cubic.getCongestionWindow(), cwnd);
 
   // 1 seconds of quiescence
@@ -216,7 +219,8 @@ TEST_F(CubicTest, AppIdle) {
   auto packet3 = makeTestingWritePacket(3, 1000, 4000);
   cubic.onPacketSent(packet3);
   cubic.onPacketAckOrLoss(
-      makeAck(3, 1000, reductionTime + 3000ms, packet3.metrics.time), folly::none);
+      makeAck(3, 1000, reductionTime + 3000ms, packet3.metadata.time),
+      folly::none);
   EXPECT_GT(cubic.getCongestionWindow(), cwnd);
 
   auto expectedDelta = static_cast<int64_t>(std::floor(
@@ -257,7 +261,7 @@ TEST_F(CubicTest, PacingGain) {
             EXPECT_EQ(cubic.getCongestionWindow() * 2, cwndBytes);
           }));
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1500, Clock::now(), packet.metrics.time), folly::none);
+      makeAck(0, 1500, Clock::now(), packet.metadata.time), folly::none);
   EXPECT_EQ(CubicStates::Hystart, cubic.state());
 
   auto packet1 = makeTestingWritePacket(1, 1500, 3000);
@@ -285,7 +289,7 @@ TEST_F(CubicTest, PacingGain) {
             EXPECT_EQ(cubic.getCongestionWindow(), cwndBytes);
           }));
   cubic.onPacketAckOrLoss(
-      makeAck(2, 1500, Clock::now(), packet2.metrics.time), folly::none);
+      makeAck(2, 1500, Clock::now(), packet2.metadata.time), folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 
   std::vector<int> indices =

--- a/quic/congestion_control/test/CubicTest.cpp
+++ b/quic/congestion_control/test/CubicTest.cpp
@@ -36,7 +36,7 @@ TEST_F(CubicTest, AckIncreaseWritable) {
 
   // Acking 50, now inflight become 50. Cwnd is init + 50
   cubic.onPacketAckOrLoss(
-      makeAck(0, 50, Clock::now(), packet.time), folly::none);
+      makeAck(0, 50, Clock::now(), packet.metrics.time), folly::none);
   EXPECT_EQ(initCwnd, cubic.getWritableBytes());
 }
 
@@ -63,7 +63,7 @@ TEST_F(CubicTest, PersistentCongestion) {
   auto packet2 = makeTestingWritePacket(1, initCwnd / 2, initCwnd / 2 + 1000);
   cubic.onPacketSent(packet2);
   cubic.onPacketAckOrLoss(
-      makeAck(1, initCwnd / 2, Clock::now(), packet2.time), folly::none);
+      makeAck(1, initCwnd / 2, Clock::now(), packet2.metrics.time), folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 
   // Verify both lastMaxCwndBytes and lastReductionTime are also reset in
@@ -74,7 +74,7 @@ TEST_F(CubicTest, PersistentCongestion) {
   auto packet3 = makeTestingWritePacket(2, 3000, initCwnd / 2 + 1000 + 3000);
   cubic.onPacketSent(packet3);
   cubic.onPacketAckOrLoss(
-      makeAck(2, 3000, Clock::now(), packet3.time), folly::none);
+      makeAck(2, 3000, Clock::now(), packet3.metrics.time), folly::none);
 
   std::vector<int> indices =
       getQLogEventIndices(QLogEventType::CongestionMetricUpdate, qLogger);
@@ -125,7 +125,7 @@ TEST_F(CubicTest, CwndIncreaseAfterReduction) {
   conn.lossState.largestSent = 0;
   cubic.onPacketSent(packet0);
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1000, Clock::now(), packet0.time), folly::none);
+      makeAck(0, 1000, Clock::now(), packet0.metrics.time), folly::none);
   // Cwnd increased by 1000, inflight = 0:
   EXPECT_EQ(3000, cubic.getWritableBytes());
   EXPECT_EQ(CubicStates::Steady, cubic.state());
@@ -142,7 +142,7 @@ TEST_F(CubicTest, CwndIncreaseAfterReduction) {
   EXPECT_EQ(0, cubic.getWritableBytes());
 
   cubic.onPacketAckOrLoss(
-      makeAck(1, 1000, Clock::now(), packet1.time), folly::none);
+      makeAck(1, 1000, Clock::now(), packet1.metrics.time), folly::none);
   // Cwnd >= 3000, inflight = 2000:
   EXPECT_GE(cubic.getWritableBytes(), 1000);
   CongestionController::LossEvent loss;
@@ -152,7 +152,7 @@ TEST_F(CubicTest, CwndIncreaseAfterReduction) {
   EXPECT_GE(cubic.getWritableBytes(), 1400);
   // This won't bring state machine back to Steady since endOfRecovery = 3
   cubic.onPacketAckOrLoss(
-      makeAck(3, 1000, Clock::now(), packet3.time), folly::none);
+      makeAck(3, 1000, Clock::now(), packet3.metrics.time), folly::none);
   // Cwnd no change, inflight = 0:
   EXPECT_GE(cubic.getWritableBytes(), 2400);
   EXPECT_EQ(CubicStates::FastRecovery, cubic.state());
@@ -162,7 +162,7 @@ TEST_F(CubicTest, CwndIncreaseAfterReduction) {
   cubic.onPacketSent(packet4);
   // This will bring state machine back to steady
   cubic.onPacketAckOrLoss(
-      makeAck(4, 1000, Clock::now(), packet4.time), folly::none);
+      makeAck(4, 1000, Clock::now(), packet4.metrics.time), folly::none);
   EXPECT_GE(cubic.getWritableBytes(), 2400);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 
@@ -197,7 +197,7 @@ TEST_F(CubicTest, AppIdle) {
   auto packet1 = makeTestingWritePacket(1, 1000, 2000);
   cubic.onPacketSent(packet1);
   cubic.onPacketAckOrLoss(
-      makeAck(1, 1000, reductionTime + 1000ms, packet1.time), folly::none);
+      makeAck(1, 1000, reductionTime + 1000ms, packet1.metrics.time), folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
   EXPECT_GT(cubic.getCongestionWindow(), cwnd);
   cwnd = cubic.getCongestionWindow();
@@ -207,7 +207,7 @@ TEST_F(CubicTest, AppIdle) {
   auto packet2 = makeTestingWritePacket(2, 1000, 3000);
   cubic.onPacketSent(packet2);
   cubic.onPacketAckOrLoss(
-      makeAck(2, 1000, reductionTime + 2000ms, packet2.time), folly::none);
+      makeAck(2, 1000, reductionTime + 2000ms, packet2.metrics.time), folly::none);
   EXPECT_EQ(cubic.getCongestionWindow(), cwnd);
 
   // 1 seconds of quiescence
@@ -216,7 +216,7 @@ TEST_F(CubicTest, AppIdle) {
   auto packet3 = makeTestingWritePacket(3, 1000, 4000);
   cubic.onPacketSent(packet3);
   cubic.onPacketAckOrLoss(
-      makeAck(3, 1000, reductionTime + 3000ms, packet3.time), folly::none);
+      makeAck(3, 1000, reductionTime + 3000ms, packet3.metrics.time), folly::none);
   EXPECT_GT(cubic.getCongestionWindow(), cwnd);
 
   auto expectedDelta = static_cast<int64_t>(std::floor(
@@ -257,7 +257,7 @@ TEST_F(CubicTest, PacingGain) {
             EXPECT_EQ(cubic.getCongestionWindow() * 2, cwndBytes);
           }));
   cubic.onPacketAckOrLoss(
-      makeAck(0, 1500, Clock::now(), packet.time), folly::none);
+      makeAck(0, 1500, Clock::now(), packet.metrics.time), folly::none);
   EXPECT_EQ(CubicStates::Hystart, cubic.state());
 
   auto packet1 = makeTestingWritePacket(1, 1500, 3000);
@@ -285,7 +285,7 @@ TEST_F(CubicTest, PacingGain) {
             EXPECT_EQ(cubic.getCongestionWindow(), cwndBytes);
           }));
   cubic.onPacketAckOrLoss(
-      makeAck(2, 1500, Clock::now(), packet2.time), folly::none);
+      makeAck(2, 1500, Clock::now(), packet2.metrics.time), folly::none);
   EXPECT_EQ(CubicStates::Steady, cubic.state());
 
   std::vector<int> indices =

--- a/quic/congestion_control/test/NewRenoTest.cpp
+++ b/quic/congestion_control/test/NewRenoTest.cpp
@@ -50,12 +50,16 @@ CongestionController::AckEvent createAckEvent(
   return ack;
 }
 
-OutstandingPacket
-createPacket(PacketNum packetNum, uint32_t size, TimePoint sendTime, uint64_t inflight = 0) {
+OutstandingPacket createPacket(
+    PacketNum packetNum,
+    uint32_t size,
+    TimePoint sendTime,
+    uint64_t inflight = 0) {
   auto connId = getTestConnectionId();
   RegularQuicWritePacket packet(
       ShortHeader(ProtectionType::KeyPhaseZero, connId, packetNum));
-  return OutstandingPacket(std::move(packet), sendTime, size, false, size, inflight);
+  return OutstandingPacket(
+      std::move(packet), sendTime, size, false, size, inflight);
 }
 
 TEST_F(NewRenoTest, TestLoss) {
@@ -130,7 +134,8 @@ TEST_F(NewRenoTest, TestSlowStartAck) {
   reno.onPacketSent(packet);
   EXPECT_EQ(reno.getBytesInFlight(), ackedSize);
   reno.onPacketAckOrLoss(
-      createAckEvent(ackPacketNum1, ackedSize, packet.metrics.time), folly::none);
+      createAckEvent(ackPacketNum1, ackedSize, packet.metadata.time),
+      folly::none);
   EXPECT_TRUE(reno.inSlowStart());
   auto newWritableBytes = reno.getWritableBytes();
 
@@ -159,7 +164,8 @@ TEST_F(NewRenoTest, TestSteadyStateAck) {
       ackPacketNum1, ackedSize, Clock::now() - std::chrono::milliseconds(10));
   reno.onPacketSent(packet1);
   reno.onPacketAckOrLoss(
-      createAckEvent(ackPacketNum1, ackedSize, packet1.metrics.time), folly::none);
+      createAckEvent(ackPacketNum1, ackedSize, packet1.metadata.time),
+      folly::none);
   EXPECT_FALSE(reno.inSlowStart());
 
   auto newWritableBytes2 = reno.getWritableBytes();
@@ -169,7 +175,8 @@ TEST_F(NewRenoTest, TestSteadyStateAck) {
   auto packet2 = createPacket(ackPacketNum2, ackedSize, Clock::now());
   reno.onPacketSent(packet2);
   reno.onPacketAckOrLoss(
-      createAckEvent(ackPacketNum2, ackedSize, packet2.metrics.time), folly::none);
+      createAckEvent(ackPacketNum2, ackedSize, packet2.metadata.time),
+      folly::none);
   EXPECT_FALSE(reno.inSlowStart());
 
   auto newWritableBytes3 = reno.getWritableBytes();

--- a/quic/congestion_control/test/NewRenoTest.cpp
+++ b/quic/congestion_control/test/NewRenoTest.cpp
@@ -27,7 +27,7 @@ CongestionController::LossEvent createLossEvent(
     RegularQuicWritePacket packet(
         ShortHeader(ProtectionType::KeyPhaseZero, connId, packetData.first));
     loss.addLostPacket(
-        OutstandingPacket(std::move(packet), Clock::now(), 10, false, 10));
+        OutstandingPacket(std::move(packet), Clock::now(), 10, false, 10, 0));
     loss.lostBytes = packetData.second;
   }
   loss.lostPackets = lostPackets.size();
@@ -46,16 +46,16 @@ CongestionController::AckEvent createAckEvent(
   ack.ackedBytes = ackedSize;
   ack.ackedPackets.push_back(
       makeAckPacketFromOutstandingPacket(OutstandingPacket(
-          std::move(packet), packetSentTime, ackedSize, false, ackedSize)));
+          std::move(packet), packetSentTime, ackedSize, false, ackedSize, 0)));
   return ack;
 }
 
 OutstandingPacket
-createPacket(PacketNum packetNum, uint32_t size, TimePoint sendTime) {
+createPacket(PacketNum packetNum, uint32_t size, TimePoint sendTime, uint64_t inflight = 0) {
   auto connId = getTestConnectionId();
   RegularQuicWritePacket packet(
       ShortHeader(ProtectionType::KeyPhaseZero, connId, packetNum));
-  return OutstandingPacket(std::move(packet), sendTime, size, false, size);
+  return OutstandingPacket(std::move(packet), sendTime, size, false, size, inflight);
 }
 
 TEST_F(NewRenoTest, TestLoss) {
@@ -130,7 +130,7 @@ TEST_F(NewRenoTest, TestSlowStartAck) {
   reno.onPacketSent(packet);
   EXPECT_EQ(reno.getBytesInFlight(), ackedSize);
   reno.onPacketAckOrLoss(
-      createAckEvent(ackPacketNum1, ackedSize, packet.time), folly::none);
+      createAckEvent(ackPacketNum1, ackedSize, packet.metrics.time), folly::none);
   EXPECT_TRUE(reno.inSlowStart());
   auto newWritableBytes = reno.getWritableBytes();
 
@@ -159,7 +159,7 @@ TEST_F(NewRenoTest, TestSteadyStateAck) {
       ackPacketNum1, ackedSize, Clock::now() - std::chrono::milliseconds(10));
   reno.onPacketSent(packet1);
   reno.onPacketAckOrLoss(
-      createAckEvent(ackPacketNum1, ackedSize, packet1.time), folly::none);
+      createAckEvent(ackPacketNum1, ackedSize, packet1.metrics.time), folly::none);
   EXPECT_FALSE(reno.inSlowStart());
 
   auto newWritableBytes2 = reno.getWritableBytes();
@@ -169,7 +169,7 @@ TEST_F(NewRenoTest, TestSteadyStateAck) {
   auto packet2 = createPacket(ackPacketNum2, ackedSize, Clock::now());
   reno.onPacketSent(packet2);
   reno.onPacketAckOrLoss(
-      createAckEvent(ackPacketNum2, ackedSize, packet2.time), folly::none);
+      createAckEvent(ackPacketNum2, ackedSize, packet2.metrics.time), folly::none);
   EXPECT_FALSE(reno.inSlowStart());
 
   auto newWritableBytes3 = reno.getWritableBytes();

--- a/quic/loss/QuicLossFunctions.h
+++ b/quic/loss/QuicLossFunctions.h
@@ -218,11 +218,11 @@ folly::Optional<CongestionController::LossEvent> detectLossPackets(
       break;
     }
     auto currentPacketNumberSpace = pkt.packet.header.getPacketNumberSpace();
-    if (currentPacketNumberSpace != pnSpace || pkt.metrics.isD6DProbe) {
+    if (currentPacketNumberSpace != pnSpace || pkt.metadata.isD6DProbe) {
       iter++;
       continue;
     }
-    bool lostByTimeout = (lossTime - pkt.metrics.time) > delayUntilLost;
+    bool lostByTimeout = (lossTime - pkt.metadata.time) > delayUntilLost;
     bool lostByReorder =
         (*largestAcked - currentPacketNum) > conn.lossState.reorderingThreshold;
 
@@ -248,7 +248,7 @@ folly::Optional<CongestionController::LossEvent> detectLossPackets(
     if (pkt.associatedEvent) {
       conn.outstandings.packetEvents.erase(*pkt.associatedEvent);
     }
-    if (pkt.metrics.isHandshake && !processed) {
+    if (pkt.metadata.isHandshake && !processed) {
       if (currentPacketNumberSpace == PacketNumberSpace::Initial) {
         CHECK(conn.outstandings.initialPacketsCount);
         --conn.outstandings.initialPacketsCount;
@@ -259,7 +259,7 @@ folly::Optional<CongestionController::LossEvent> detectLossPackets(
       }
     }
     VLOG(10) << __func__ << " lost packetNum=" << currentPacketNum
-             << " handshake=" << pkt.metrics.isHandshake << " " << conn;
+             << " handshake=" << pkt.metadata.isHandshake << " " << conn;
     // Rather than erasing here, instead mark the packet as lost so we can
     // determine if this was spurious later.
     conn.outstandings.declaredLostCount++;
@@ -291,7 +291,7 @@ folly::Optional<CongestionController::LossEvent> detectLossPackets(
              << conn.outstandings.packets.empty() << " delayUntilLost"
              << delayUntilLost.count() << "us"
              << " " << conn;
-    getLossTime(conn, pnSpace) = delayUntilLost + earliest->metrics.time;
+    getLossTime(conn, pnSpace) = delayUntilLost + earliest->metadata.time;
   }
   if (lossEvent.largestLostPacketNum.hasValue()) {
     DCHECK(lossEvent.largestLostSentTime && lossEvent.smallestLostSentTime);
@@ -422,7 +422,7 @@ void markZeroRttPacketsLost(
         iter->packet.header.getProtectionType() == ProtectionType::ZeroRtt;
     if (isZeroRttPacket) {
       auto& pkt = *iter;
-      DCHECK(!pkt.metrics.isHandshake);
+      DCHECK(!pkt.metadata.isHandshake);
       bool processed = pkt.associatedEvent &&
           !conn.outstandings.packetEvents.count(*pkt.associatedEvent);
       lossVisitor(conn, pkt.packet, processed);

--- a/quic/loss/test/QuicLossFunctionsTest.cpp
+++ b/quic/loss/test/QuicLossFunctionsTest.cpp
@@ -205,7 +205,7 @@ PacketNum QuicLossFunctionsTest::sendPacket(
     encodedSize += packet.body->computeChainDataLength();
   }
   auto outstandingPacket = OutstandingPacket(
-      packet.packet, time, encodedSize, isHandshake, isD6DProbe, encodedSize);
+      packet.packet, time, encodedSize, isHandshake, isD6DProbe, encodedSize, 0);
   outstandingPacket.associatedEvent = associatedEvent;
   if (isHandshake) {
     conn.lossState.lastHandshakePacketSentTime = time;
@@ -755,7 +755,7 @@ TEST_F(QuicLossFunctionsTest, TestReorderingThreshold) {
        iter <
        getFirstOutstandingPacket(*conn, PacketNumberSpace::Handshake) + 5;
        iter++) {
-    if (iter->isHandshake) {
+    if (iter->metrics.isHandshake) {
       conn->outstandings.handshakePacketsCount--;
     }
   }
@@ -807,7 +807,7 @@ TEST_F(QuicLossFunctionsTest, TestHandleAckForLoss) {
   RegularQuicWritePacket outstandingRegularPacket(std::move(longHeader));
   auto now = Clock::now();
   conn->outstandings.packets.emplace_back(
-      OutstandingPacket(outstandingRegularPacket, now, 0, false, 0));
+      OutstandingPacket(outstandingRegularPacket, now, 0, false, 0, 0));
 
   bool testLossMarkFuncCalled = false;
   auto testLossMarkFunc = [&](auto& /* conn */, auto&, bool) {

--- a/quic/loss/test/QuicLossFunctionsTest.cpp
+++ b/quic/loss/test/QuicLossFunctionsTest.cpp
@@ -205,7 +205,13 @@ PacketNum QuicLossFunctionsTest::sendPacket(
     encodedSize += packet.body->computeChainDataLength();
   }
   auto outstandingPacket = OutstandingPacket(
-      packet.packet, time, encodedSize, isHandshake, isD6DProbe, encodedSize, 0);
+      packet.packet,
+      time,
+      encodedSize,
+      isHandshake,
+      isD6DProbe,
+      encodedSize,
+      0);
   outstandingPacket.associatedEvent = associatedEvent;
   if (isHandshake) {
     conn.lossState.lastHandshakePacketSentTime = time;
@@ -755,7 +761,7 @@ TEST_F(QuicLossFunctionsTest, TestReorderingThreshold) {
        iter <
        getFirstOutstandingPacket(*conn, PacketNumberSpace::Handshake) + 5;
        iter++) {
-    if (iter->metrics.isHandshake) {
+    if (iter->metadata.isHandshake) {
       conn->outstandings.handshakePacketsCount--;
     }
   }

--- a/quic/server/state/ServerStateMachine.cpp
+++ b/quic/server/state/ServerStateMachine.cpp
@@ -892,7 +892,7 @@ void onServerReadDataFromOpen(
                     break;
                   }
                   case QuicWriteFrame::Type::PingFrame_E:
-                    if (!packet.isD6DProbe) {
+                    if (!packet.metrics.isD6DProbe) {
                       conn.pendingEvents.cancelPingTimeout = true;
                     }
                     return;

--- a/quic/server/state/ServerStateMachine.cpp
+++ b/quic/server/state/ServerStateMachine.cpp
@@ -892,7 +892,7 @@ void onServerReadDataFromOpen(
                     break;
                   }
                   case QuicWriteFrame::Type::PingFrame_E:
-                    if (!packet.metrics.isD6DProbe) {
+                    if (!packet.metadata.isD6DProbe) {
                       conn.pendingEvents.cancelPingTimeout = true;
                     }
                     return;
@@ -908,9 +908,7 @@ void onServerReadDataFromOpen(
                     }
                     break;
                   }
-                  default: {
-                    break;
-                  }
+                  default: { break; }
                 }
               },
               markPacketLoss,
@@ -1058,9 +1056,7 @@ void onServerReadDataFromOpen(
               conn, simpleFrame, packetNum, readData.peer != conn.peerAddress);
           break;
         }
-        default: {
-          break;
-        }
+        default: { break; }
       }
     }
 

--- a/quic/state/AckHandlers.cpp
+++ b/quic/state/AckHandlers.cpp
@@ -145,7 +145,7 @@ void processAckFrame(
           ackReceiveTimeOrNow - rPacketIt->metadata.time);
       if (!ack.implicit && currentPacketNum == frame.largestAcked) {
         InstrumentationObserver::PacketRTT packetRTT(
-            rttSample, frame.ackDelay, *rPacketIt);
+            ackReceiveTimeOrNow, rttSample, frame.ackDelay, *rPacketIt);
         for (const auto& observer : conn.instrumentationObservers_) {
           conn.pendingCallbacks.emplace_back([observer, packetRTT] {
             observer->rttSampleGenerated(packetRTT);

--- a/quic/state/OutstandingPacket.h
+++ b/quic/state/OutstandingPacket.h
@@ -13,7 +13,7 @@
 
 namespace quic {
 
-struct OutstandingPacketMetrics {
+struct OutstandingPacketMetadata {
   // Time that the packet was sent.
   TimePoint time;
   // Size of the packet sent on the wire.
@@ -29,7 +29,7 @@ struct OutstandingPacketMetrics {
   // packet is sent.
   uint64_t inflightBytes;
 
-  OutstandingPacketMetrics(
+  OutstandingPacketMetadata(
       TimePoint timeIn,
       uint32_t encodedSizeIn,
       bool isHandshakeIn,
@@ -49,8 +49,9 @@ struct OutstandingPacket {
   // Structure representing the frames that are outstanding including the header
   // that was sent.
   RegularQuicWritePacket packet;
-  // Structure representing a collection of metrics about the packet.
-  OutstandingPacketMetrics metrics;
+  // Structure representing a collection of metrics and important information
+  // about the packet.
+  OutstandingPacketMetadata metadata;
   // Information regarding the last acked packet on this connection when this
   // packet is sent.
   struct LastAckedPacketInfo {
@@ -92,36 +93,36 @@ struct OutstandingPacket {
   bool declaredLost{false};
 
   OutstandingPacket(
-      RegularQuicWritePacket packetIn, 
-      TimePoint timeIn, 
-      uint32_t encodedSizeIn, 
-      bool isHandshakeIn, 
-      uint64_t totalBytesSentIn, 
-      uint64_t inflightBytesIn) 
-    : packet(std::move(packetIn)), 
-      metrics(OutstandingPacketMetrics(
-          std::move(timeIn), 
-          encodedSizeIn, 
-          isHandshakeIn, 
-          false,
-          totalBytesSentIn, 
-          inflightBytesIn)) {}
+      RegularQuicWritePacket packetIn,
+      TimePoint timeIn,
+      uint32_t encodedSizeIn,
+      bool isHandshakeIn,
+      uint64_t totalBytesSentIn,
+      uint64_t inflightBytesIn)
+      : packet(std::move(packetIn)),
+        metadata(OutstandingPacketMetadata(
+            std::move(timeIn),
+            encodedSizeIn,
+            isHandshakeIn,
+            false,
+            totalBytesSentIn,
+            inflightBytesIn)) {}
 
   OutstandingPacket(
-      RegularQuicWritePacket packetIn, 
-      TimePoint timeIn, 
-      uint32_t encodedSizeIn, 
-      bool isHandshakeIn, 
+      RegularQuicWritePacket packetIn,
+      TimePoint timeIn,
+      uint32_t encodedSizeIn,
+      bool isHandshakeIn,
       bool isD6DProbeIn,
-      uint64_t totalBytesSentIn, 
-      uint64_t inflightBytesIn) 
-    : packet(std::move(packetIn)), 
-      metrics(OutstandingPacketMetrics(
-          std::move(timeIn), 
-          encodedSizeIn, 
-          isHandshakeIn, 
-          isD6DProbeIn,
-          totalBytesSentIn, 
-          inflightBytesIn)) {}
+      uint64_t totalBytesSentIn,
+      uint64_t inflightBytesIn)
+      : packet(std::move(packetIn)),
+        metadata(OutstandingPacketMetadata(
+            std::move(timeIn),
+            encodedSizeIn,
+            isHandshakeIn,
+            isD6DProbeIn,
+            totalBytesSentIn,
+            inflightBytesIn)) {}
 };
 } // namespace quic

--- a/quic/state/OutstandingPacket.h
+++ b/quic/state/OutstandingPacket.h
@@ -12,11 +12,8 @@
 #include <quic/state/PacketEvent.h>
 
 namespace quic {
-// Data structure to represent outstanding retransmittable packets
-struct OutstandingPacket {
-  // Structure representing the frames that are outstanding including the header
-  // that was sent.
-  RegularQuicWritePacket packet;
+
+struct OutstandingPacketMetrics {
   // Time that the packet was sent.
   TimePoint time;
   // Size of the packet sent on the wire.
@@ -28,6 +25,32 @@ struct OutstandingPacket {
   // Total sent bytes on this connection including this packet itself when this
   // packet is sent.
   uint64_t totalBytesSent;
+  // Bytes in flight on this connection including this packet itself when this
+  // packet is sent.
+  uint64_t inflightBytes;
+
+  OutstandingPacketMetrics(
+      TimePoint timeIn,
+      uint32_t encodedSizeIn,
+      bool isHandshakeIn,
+      bool isD6DProbeIn,
+      uint64_t totalBytesSentIn,
+      uint64_t inflightBytesIn)
+      : time(std::move(timeIn)),
+        encodedSize(encodedSizeIn),
+        isHandshake(isHandshakeIn),
+        isD6DProbe(isD6DProbeIn),
+        totalBytesSent(totalBytesSentIn),
+        inflightBytes(inflightBytesIn) {}
+};
+
+// Data structure to represent outstanding retransmittable packets
+struct OutstandingPacket {
+  // Structure representing the frames that are outstanding including the header
+  // that was sent.
+  RegularQuicWritePacket packet;
+  // Structure representing a collection of metrics about the packet.
+  OutstandingPacketMetrics metrics;
   // Information regarding the last acked packet on this connection when this
   // packet is sent.
   struct LastAckedPacketInfo {
@@ -69,30 +92,36 @@ struct OutstandingPacket {
   bool declaredLost{false};
 
   OutstandingPacket(
-      RegularQuicWritePacket packetIn,
-      TimePoint timeIn,
-      uint32_t encodedSizeIn,
-      bool isHandshakeIn,
-      uint64_t totalBytesSentIn)
-      : packet(std::move(packetIn)),
-        time(std::move(timeIn)),
-        encodedSize(encodedSizeIn),
-        isHandshake(isHandshakeIn),
-        isD6DProbe(false),
-        totalBytesSent(totalBytesSentIn) {}
+      RegularQuicWritePacket packetIn, 
+      TimePoint timeIn, 
+      uint32_t encodedSizeIn, 
+      bool isHandshakeIn, 
+      uint64_t totalBytesSentIn, 
+      uint64_t inflightBytesIn) 
+    : packet(std::move(packetIn)), 
+      metrics(OutstandingPacketMetrics(
+          std::move(timeIn), 
+          encodedSizeIn, 
+          isHandshakeIn, 
+          false,
+          totalBytesSentIn, 
+          inflightBytesIn)) {}
 
   OutstandingPacket(
-      RegularQuicWritePacket packetIn,
-      TimePoint timeIn,
-      uint32_t encodedSizeIn,
-      bool isHandshakeIn,
+      RegularQuicWritePacket packetIn, 
+      TimePoint timeIn, 
+      uint32_t encodedSizeIn, 
+      bool isHandshakeIn, 
       bool isD6DProbeIn,
-      uint64_t totalBytesSentIn)
-      : packet(std::move(packetIn)),
-        time(std::move(timeIn)),
-        encodedSize(encodedSizeIn),
-        isHandshake(isHandshakeIn),
-        isD6DProbe(isD6DProbeIn),
-        totalBytesSent(totalBytesSentIn) {}
+      uint64_t totalBytesSentIn, 
+      uint64_t inflightBytesIn) 
+    : packet(std::move(packetIn)), 
+      metrics(OutstandingPacketMetrics(
+          std::move(timeIn), 
+          encodedSizeIn, 
+          isHandshakeIn, 
+          isD6DProbeIn,
+          totalBytesSentIn, 
+          inflightBytesIn)) {}
 };
 } // namespace quic

--- a/quic/state/StateData.h
+++ b/quic/state/StateData.h
@@ -224,7 +224,7 @@ struct CongestionController {
 
     void addLostPacket(const OutstandingPacket& packet) {
       if (std::numeric_limits<uint64_t>::max() - lostBytes <
-          packet.metrics.encodedSize) {
+          packet.metadata.encodedSize) {
         throw QuicInternalException(
             "LossEvent: lostBytes overflow",
             LocalErrorCode::LOST_BYTES_OVERFLOW);
@@ -232,12 +232,14 @@ struct CongestionController {
       PacketNum packetNum = packet.packet.header.getPacketSequenceNum();
       largestLostPacketNum =
           std::max(packetNum, largestLostPacketNum.value_or(packetNum));
-      lostBytes += packet.metrics.encodedSize;
+      lostBytes += packet.metadata.encodedSize;
       lostPackets++;
-      largestLostSentTime =
-          std::max(packet.metrics.time, largestLostSentTime.value_or(packet.metrics.time));
-      smallestLostSentTime =
-          std::min(packet.metrics.time, smallestLostSentTime.value_or(packet.metrics.time));
+      largestLostSentTime = std::max(
+          packet.metadata.time,
+          largestLostSentTime.value_or(packet.metadata.time));
+      smallestLostSentTime = std::min(
+          packet.metadata.time,
+          smallestLostSentTime.value_or(packet.metadata.time));
     }
   };
 

--- a/quic/state/StateData.h
+++ b/quic/state/StateData.h
@@ -224,7 +224,7 @@ struct CongestionController {
 
     void addLostPacket(const OutstandingPacket& packet) {
       if (std::numeric_limits<uint64_t>::max() - lostBytes <
-          packet.encodedSize) {
+          packet.metrics.encodedSize) {
         throw QuicInternalException(
             "LossEvent: lostBytes overflow",
             LocalErrorCode::LOST_BYTES_OVERFLOW);
@@ -232,12 +232,12 @@ struct CongestionController {
       PacketNum packetNum = packet.packet.header.getPacketSequenceNum();
       largestLostPacketNum =
           std::max(packetNum, largestLostPacketNum.value_or(packetNum));
-      lostBytes += packet.encodedSize;
+      lostBytes += packet.metrics.encodedSize;
       lostPackets++;
       largestLostSentTime =
-          std::max(packet.time, largestLostSentTime.value_or(packet.time));
+          std::max(packet.metrics.time, largestLostSentTime.value_or(packet.metrics.time));
       smallestLostSentTime =
-          std::min(packet.time, smallestLostSentTime.value_or(packet.time));
+          std::min(packet.metrics.time, smallestLostSentTime.value_or(packet.metrics.time));
     }
   };
 

--- a/quic/state/test/AckHandlersTest.cpp
+++ b/quic/state/test/AckHandlersTest.cpp
@@ -17,6 +17,7 @@
 #include <quic/state/AckHandlers.h>
 #include <quic/state/StateData.h>
 #include <quic/state/test/Mocks.h>
+#include <quic/api/test/Mocks.h>
 
 #include <numeric>
 
@@ -52,7 +53,7 @@ TEST_P(AckHandlersTest, TestAckMultipleSequentialBlocks) {
     WriteStreamFrame frame(currentStreamId++, 0, 0, true);
     regularPacket.frames.emplace_back(std::move(frame));
     conn.outstandings.packets.emplace_back(OutstandingPacket(
-        std::move(regularPacket), sentTime, 1, false, packetNum));
+        std::move(regularPacket), sentTime, 1, false, packetNum, 0));
   }
   ReadAckFrame ackFrame;
   ackFrame.largestAcked = 101;
@@ -123,7 +124,7 @@ TEST_P(AckHandlersTest, TestAckMultipleSequentialBlocksLoss) {
     WriteStreamFrame frame(currentStreamId++, 0, 0, true);
     regularPacket.frames.emplace_back(std::move(frame));
     conn.outstandings.packets.emplace_back(OutstandingPacket(
-        std::move(regularPacket), sentTime, 1, false, packetNum));
+        std::move(regularPacket), sentTime, 1, false, packetNum, 0));
   }
   ReadAckFrame ackFrame;
   ackFrame.largestAcked = 101;
@@ -258,7 +259,7 @@ TEST_P(AckHandlersTest, TestAckBlocksWithGaps) {
     WriteStreamFrame frame(currentStreamId++, 0, 0, true);
     regularPacket.frames.emplace_back(std::move(frame));
     conn.outstandings.packets.emplace_back(OutstandingPacket(
-        std::move(regularPacket), Clock::now(), 1, false, packetNum));
+        std::move(regularPacket), Clock::now(), 1, false, packetNum, 0));
   }
 
   ReadAckFrame ackFrame;
@@ -356,7 +357,7 @@ TEST_P(AckHandlersTest, TestNonSequentialPacketNumbers) {
     WriteStreamFrame frame(current++, 0, 0, true);
     regularPacket.frames.emplace_back(std::move(frame));
     conn.outstandings.packets.emplace_back(OutstandingPacket(
-        std::move(regularPacket), Clock::now(), 1, false, packetNum));
+        std::move(regularPacket), Clock::now(), 1, false, packetNum, 0));
   }
 
   for (PacketNum packetNum = 20; packetNum < 40; packetNum += 3) {
@@ -365,7 +366,7 @@ TEST_P(AckHandlersTest, TestNonSequentialPacketNumbers) {
     current += 3;
     regularPacket.frames.emplace_back(std::move(frame));
     conn.outstandings.packets.emplace_back(OutstandingPacket(
-        std::move(regularPacket), Clock::now(), 1, false, packetNum));
+        std::move(regularPacket), Clock::now(), 1, false, packetNum, 0));
   }
 
   ReadAckFrame ackFrame;
@@ -446,7 +447,7 @@ TEST_P(AckHandlersTest, AckVisitorForAckTest) {
   conn.ackStates.appDataAckState.acks.insert(500, 700);
   firstPacket.frames.emplace_back(std::move(firstAckFrame));
   conn.outstandings.packets.emplace_back(
-      OutstandingPacket(std::move(firstPacket), Clock::now(), 0, false, 0));
+      OutstandingPacket(std::move(firstPacket), Clock::now(), 0, false, 0, 0));
 
   auto secondPacket = createNewPacket(101 /* packetNum */, GetParam());
   WriteAckFrame secondAckFrame;
@@ -456,7 +457,7 @@ TEST_P(AckHandlersTest, AckVisitorForAckTest) {
   conn.ackStates.appDataAckState.acks.insert(1002, 1090);
   secondPacket.frames.emplace_back(std::move(secondAckFrame));
   conn.outstandings.packets.emplace_back(
-      OutstandingPacket(std::move(secondPacket), Clock::now(), 0, false, 0));
+      OutstandingPacket(std::move(secondPacket), Clock::now(), 0, false, 0, 0));
 
   ReadAckFrame firstReceivedAck;
   firstReceivedAck.largestAcked = 100;
@@ -517,7 +518,7 @@ TEST_P(AckHandlersTest, NoNewAckedPacket) {
   PacketNum packetAfterRtoNum = 10;
   auto packetAfterRto = createNewPacket(packetAfterRtoNum, GetParam());
   conn.outstandings.packets.emplace_back(
-      OutstandingPacket(std::move(packetAfterRto), Clock::now(), 0, false, 0));
+      OutstandingPacket(std::move(packetAfterRto), Clock::now(), 0, false, 0, 0));
 
   ReadAckFrame ackFrame;
   ackFrame.largestAcked = 5;
@@ -563,12 +564,12 @@ TEST_P(AckHandlersTest, AckPacketNumDoesNotExist) {
   PacketNum packetNum1 = 9;
   auto regularPacket1 = createNewPacket(packetNum1, GetParam());
   conn.outstandings.packets.emplace_back(
-      std::move(regularPacket1), Clock::now(), 0, false, 0);
+      std::move(regularPacket1), Clock::now(), 0, false, 0, 0);
 
   PacketNum packetNum2 = 10;
   auto regularPacket2 = createNewPacket(packetNum2, GetParam());
   conn.outstandings.packets.emplace_back(
-      std::move(regularPacket2), Clock::now(), 0, false, 0);
+      std::move(regularPacket2), Clock::now(), 0, false, 0, 0);
 
   // Ack a packet one higher than the packet so that we don't trigger reordering
   // threshold.
@@ -601,7 +602,7 @@ TEST_P(AckHandlersTest, TestHandshakeCounterUpdate) {
         Clock::now(),
         0,
         packetNum % 2 && GetParam() != PacketNumberSpace::AppData,
-        packetNum / 2);
+        packetNum / 2, 0);
     if (GetParam() == PacketNumberSpace::Initial) {
       conn.outstandings.initialPacketsCount += packetNum % 2;
     } else if (GetParam() == PacketNumberSpace::Handshake) {
@@ -684,7 +685,7 @@ TEST_P(AckHandlersTest, NoSkipAckVisitor) {
   WriteStreamFrame frame(0, 0, 0, true);
   regularPacket.frames.emplace_back(std::move(frame));
   conn.outstandings.packets.emplace_back(
-      OutstandingPacket(std::move(regularPacket), Clock::now(), 1, false, 1));
+      OutstandingPacket(std::move(regularPacket), Clock::now(), 1, false, 1, 0));
   ReadAckFrame ackFrame;
   ackFrame.largestAcked = 0;
   ackFrame.ackBlocks.emplace_back(0, 0);
@@ -726,7 +727,7 @@ TEST_P(AckHandlersTest, SkipAckVisitor) {
   WriteStreamFrame frame(0, 0, 0, true);
   regularPacket.frames.emplace_back(std::move(frame));
   OutstandingPacket outstandingPacket(
-      std::move(regularPacket), Clock::now(), 1, false, 1);
+      std::move(regularPacket), Clock::now(), 1, false, 1, 0);
   // Give this outstandingPacket an associatedEvent that's not in
   // outstandings.packetEvents
   outstandingPacket.associatedEvent.emplace(PacketNumberSpace::AppData, 0);
@@ -767,12 +768,12 @@ TEST_P(AckHandlersTest, NoDoubleProcess) {
   regularPacket2.frames.push_back(frame);
 
   OutstandingPacket outstandingPacket1(
-      std::move(regularPacket1), Clock::now(), 1, false, 1);
+      std::move(regularPacket1), Clock::now(), 1, false, 1, 0);
   outstandingPacket1.associatedEvent.emplace(
       PacketNumberSpace::AppData, packetNum1);
 
   OutstandingPacket outstandingPacket2(
-      std::move(regularPacket2), Clock::now(), 1, false, 1);
+      std::move(regularPacket2), Clock::now(), 1, false, 1, 0);
   // The seconds packet has the same PacketEvent
   outstandingPacket2.associatedEvent.emplace(
       PacketNumberSpace::AppData, packetNum1);
@@ -829,7 +830,7 @@ TEST_P(AckHandlersTest, ClonedPacketsCounter) {
   auto regularPacket1 = createNewPacket(packetNum1, GetParam());
   regularPacket1.frames.push_back(frame);
   OutstandingPacket outstandingPacket1(
-      std::move(regularPacket1), Clock::now(), 1, false, 1);
+      std::move(regularPacket1), Clock::now(), 1, false, 1, 0);
   outstandingPacket1.associatedEvent.emplace(
       PacketNumberSpace::AppData, packetNum1);
 
@@ -838,7 +839,7 @@ TEST_P(AckHandlersTest, ClonedPacketsCounter) {
   auto regularPacket2 = createNewPacket(packetNum2, GetParam());
   regularPacket2.frames.push_back(frame);
   OutstandingPacket outstandingPacket2(
-      std::move(regularPacket2), Clock::now(), 1, false, 1);
+      std::move(regularPacket2), Clock::now(), 1, false, 1, 0);
 
   conn.outstandings.packets.push_back(std::move(outstandingPacket1));
   conn.outstandings.packets.push_back(std::move(outstandingPacket2));
@@ -877,7 +878,7 @@ TEST_P(AckHandlersTest, UpdateMaxAckDelay) {
   auto regularPacket = createNewPacket(packetNum, GetParam());
   auto sentTime = Clock::now();
   conn.outstandings.packets.emplace_back(
-      OutstandingPacket(std::move(regularPacket), sentTime, 1, false, 1));
+      OutstandingPacket(std::move(regularPacket), sentTime, 1, false, 1, 0));
 
   ReadAckFrame ackFrame;
   // ackDelay has no effect on mrtt
@@ -933,7 +934,8 @@ TEST_P(AckHandlersTest, AckNotOutstandingButLoss) {
       Clock::now() - delayUntilLost - 20ms,
       1,
       false,
-      1);
+      1,
+      0);
   conn.outstandings.packets.push_back(std::move(outstandingPacket));
   conn.outstandings.clonedPacketsCount++;
 
@@ -976,7 +978,8 @@ TEST_P(AckHandlersTest, UpdatePendingAckStates) {
       sentTime,
       111,
       false,
-      conn.lossState.totalBytesSent + 111));
+      conn.lossState.totalBytesSent + 111,
+      0));
   conn.lossState.totalBytesSent += 111;
 
   ReadAckFrame ackFrame;
@@ -1019,7 +1022,8 @@ TEST_P(AckHandlersTest, AckEventCreation) {
         largestSentTime,
         1,
         false /* handshake */,
-        packetNum);
+        packetNum,
+        0);
     sentPacket.isAppLimited = (packetNum % 2);
     conn.outstandings.packets.emplace_back(sentPacket);
     packetNum++;
@@ -1073,7 +1077,8 @@ TEST_P(AckHandlersTest, ImplictAckEventCreation) {
         largestSentTime,
         1,
         false /* handshake */,
-        packetNum);
+        packetNum,
+        packetNum + 1);
     sentPacket.isAppLimited = (packetNum % 2);
     conn.outstandings.packets.emplace_back(sentPacket);
     packetNum++;
@@ -1105,6 +1110,74 @@ TEST_P(AckHandlersTest, ImplictAckEventCreation) {
       [](const auto&, const auto&, const auto&) {},
       [](auto&, auto&, bool) {},
       ackTime);
+ }
+
+TEST_P(AckHandlersTest, TestRTTPacketObserverCallback) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  auto mockCongestionController = std::make_unique<MockCongestionController>();
+  conn.congestionController = std::move(mockCongestionController);
+
+  // Register 1 instrumentation observer
+  auto ib = MockInstrumentationObserver();
+  conn.instrumentationObservers_.emplace_back(&ib);
+
+  PacketNum packetNum = 0;
+  StreamId streamid = 0;
+  TimePoint largestSentTime;
+  while (packetNum < 10) {
+    auto regularPacket = createNewPacket(packetNum, GetParam());
+    WriteStreamFrame frame(streamid++, 0, 0, true);
+    regularPacket.frames.emplace_back(std::move(frame));
+    largestSentTime =
+        Clock::now() - 100ms + std::chrono::milliseconds(packetNum);
+    OutstandingPacket sentPacket(
+        std::move(regularPacket),
+        largestSentTime,
+        1,
+        false /* handshake */,
+        packetNum,
+        packetNum + 1);
+    sentPacket.isAppLimited = false;
+    conn.outstandings.packets.emplace_back(sentPacket);
+    packetNum++;
+  }
+
+  ReadAckFrame ackFrame;
+  ackFrame.largestAcked = 9;
+  ackFrame.ackDelay = 25ms;
+  ackFrame.ackBlocks.emplace_back(0, 9);
+
+  // 0 pending callbacks
+  EXPECT_EQ(0, size(conn.pendingCallbacks));
+
+  auto ackTime = Clock::now() + 25ms;
+  processAckFrame(
+      conn,
+      GetParam(),
+      ackFrame,
+      [](const auto&, const auto&, const auto&) {},
+      [](auto&, auto&, bool) {},
+      ackTime);
+
+  // 1 pending callbacks
+  EXPECT_EQ(1, size(conn.pendingCallbacks));
+
+  auto rttSample = std::chrono::duration_cast<std::chrono::microseconds>(
+      ackTime - largestSentTime);
+  EXPECT_CALL(
+    ib,
+    rttSampleGenerated(
+      AllOf(
+        Field(&InstrumentationObserver::PacketRTT::rttSample, rttSample),
+        Field(&InstrumentationObserver::PacketRTT::ackDelay, 25ms),
+        Field(&InstrumentationObserver::PacketRTT::metrics, Field(&quic::OutstandingPacketMetrics::inflightBytes, 10))))
+      )
+    .Times(1);
+
+  for(auto& callback : conn.pendingCallbacks) {
+    callback();
+  }
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/quic/state/test/QuicStateFunctionsTest.cpp
+++ b/quic/state/test/QuicStateFunctionsTest.cpp
@@ -553,43 +553,46 @@ TEST_F(QuicStateFunctionsTest, GetOutstandingPackets) {
       Clock::now(),
       135,
       false,
+      0,
       0);
   conn.outstandings.packets.emplace_back(
       makeTestLongPacket(LongHeader::Types::Handshake),
       Clock::now(),
       1217,
       false,
+      0,
       0);
   conn.outstandings.packets.emplace_back(
-      makeTestShortPacket(), Clock::now(), 5556, false, 0);
+      makeTestShortPacket(), Clock::now(), 5556, false, 0, 0);
   conn.outstandings.packets.emplace_back(
       makeTestLongPacket(LongHeader::Types::Initial),
       Clock::now(),
       56,
       false,
+      0,
       0);
   conn.outstandings.packets.emplace_back(
-      makeTestShortPacket(), Clock::now(), 6665, false, 0);
+      makeTestShortPacket(), Clock::now(), 6665, false, 0, 0);
   EXPECT_EQ(
       135,
-      getFirstOutstandingPacket(conn, PacketNumberSpace::Initial)->encodedSize);
+      getFirstOutstandingPacket(conn, PacketNumberSpace::Initial)->metrics.encodedSize);
   EXPECT_EQ(
       56,
-      getLastOutstandingPacket(conn, PacketNumberSpace::Initial)->encodedSize);
+      getLastOutstandingPacket(conn, PacketNumberSpace::Initial)->metrics.encodedSize);
   EXPECT_EQ(
       1217,
       getFirstOutstandingPacket(conn, PacketNumberSpace::Handshake)
-          ->encodedSize);
+          ->metrics.encodedSize);
   EXPECT_EQ(
       1217,
       getFirstOutstandingPacket(conn, PacketNumberSpace::Handshake)
-          ->encodedSize);
+          ->metrics.encodedSize);
   EXPECT_EQ(
       5556,
-      getFirstOutstandingPacket(conn, PacketNumberSpace::AppData)->encodedSize);
+      getFirstOutstandingPacket(conn, PacketNumberSpace::AppData)->metrics.encodedSize);
   EXPECT_EQ(
       6665,
-      getLastOutstandingPacket(conn, PacketNumberSpace::AppData)->encodedSize);
+      getLastOutstandingPacket(conn, PacketNumberSpace::AppData)->metrics.encodedSize);
 }
 
 TEST_F(QuicStateFunctionsTest, UpdateLargestReceivePacketsAtLatCloseSent) {

--- a/quic/state/test/QuicStateFunctionsTest.cpp
+++ b/quic/state/test/QuicStateFunctionsTest.cpp
@@ -575,24 +575,28 @@ TEST_F(QuicStateFunctionsTest, GetOutstandingPackets) {
       makeTestShortPacket(), Clock::now(), 6665, false, 0, 0);
   EXPECT_EQ(
       135,
-      getFirstOutstandingPacket(conn, PacketNumberSpace::Initial)->metrics.encodedSize);
+      getFirstOutstandingPacket(conn, PacketNumberSpace::Initial)
+          ->metadata.encodedSize);
   EXPECT_EQ(
       56,
-      getLastOutstandingPacket(conn, PacketNumberSpace::Initial)->metrics.encodedSize);
+      getLastOutstandingPacket(conn, PacketNumberSpace::Initial)
+          ->metadata.encodedSize);
   EXPECT_EQ(
       1217,
       getFirstOutstandingPacket(conn, PacketNumberSpace::Handshake)
-          ->metrics.encodedSize);
+          ->metadata.encodedSize);
   EXPECT_EQ(
       1217,
       getFirstOutstandingPacket(conn, PacketNumberSpace::Handshake)
-          ->metrics.encodedSize);
+          ->metadata.encodedSize);
   EXPECT_EQ(
       5556,
-      getFirstOutstandingPacket(conn, PacketNumberSpace::AppData)->metrics.encodedSize);
+      getFirstOutstandingPacket(conn, PacketNumberSpace::AppData)
+          ->metadata.encodedSize);
   EXPECT_EQ(
       6665,
-      getLastOutstandingPacket(conn, PacketNumberSpace::AppData)->metrics.encodedSize);
+      getLastOutstandingPacket(conn, PacketNumberSpace::AppData)
+          ->metadata.encodedSize);
 }
 
 TEST_F(QuicStateFunctionsTest, UpdateLargestReceivePacketsAtLatCloseSent) {

--- a/quic/state/test/StateDataTest.cpp
+++ b/quic/state/test/StateDataTest.cpp
@@ -35,7 +35,7 @@ TEST_F(StateDataTest, SingleLostPacketEvent) {
       getTestConnectionId(),
       100,
       kVersion));
-  OutstandingPacket outstandingPacket(packet, Clock::now(), 1234, false, 1234);
+  OutstandingPacket outstandingPacket(packet, Clock::now(), 1234, false, 1234, 0);
   CongestionController::LossEvent loss;
   loss.addLostPacket(outstandingPacket);
   EXPECT_EQ(1234, loss.lostBytes);
@@ -50,7 +50,7 @@ TEST_F(StateDataTest, MultipleLostPacketsEvent) {
       100,
       kVersion));
   OutstandingPacket outstandingPacket1(
-      packet1, Clock::now(), 1234, false, 1234);
+      packet1, Clock::now(), 1234, false, 1234, 0);
 
   RegularQuicWritePacket packet2(LongHeader(
       LongHeader::Types::Initial,
@@ -59,7 +59,7 @@ TEST_F(StateDataTest, MultipleLostPacketsEvent) {
       110,
       kVersion));
   OutstandingPacket outstandingPacket2(
-      packet2, Clock::now(), 1357, false, 1357);
+      packet2, Clock::now(), 1357, false, 1357, 0);
 
   CongestionController::LossEvent loss;
   loss.addLostPacket(outstandingPacket1);


### PR DESCRIPTION
Summary:
Due to high number of RTT samples I refactored the OutstandingPacket to
split the packet data and packet metrics. We know have access to metrics
without the need of saving the packet data.