### PR TITLE
Reverting LostPacket to save packet

### DIFF
--- a/quic/api/Observer.h
+++ b/quic/api/Observer.h
@@ -29,13 +29,10 @@ class InstrumentationObserver {
         const quic::OutstandingPacket& pkt)
         : lostByTimeout(lostbytimeout),
           lostByReorderThreshold(lostbyreorder),
-          metadata(pkt.metadata),
-          lastAckedPacketInfo(pkt.lastAckedPacketInfo) {}
+          packet(pkt) {}
     bool lostByTimeout{false};
     bool lostByReorderThreshold{false};
-    const quic::OutstandingPacketMetadata metadata;
-    const folly::Optional<OutstandingPacket::LastAckedPacketInfo>
-        lastAckedPacketInfo;
+    const quic::OutstandingPacket packet;
   };
 
   struct ObserverLossEvent {


### PR DESCRIPTION
In #178 we actually want to get the original packet. Reverting to expose the packet.