### PR TITLE
Adding spurious loss to instrumentationObserver

### DIFF
--- a/quic/api/Observer.h
+++ b/quic/api/Observer.h
@@ -129,6 +129,21 @@ class InstrumentationObserver {
     ProbeSizeRaiserType probeSizeRaiserType;
   };
 
+  struct ObserverSpuriousLossEvent {
+    explicit ObserverSpuriousLossEvent(TimePoint rcvTimeIn)
+        : rcvTime(rcvTimeIn) {}
+    TimePoint rcvTime;
+
+    bool hasPackets() {
+      return spuriousPackets.size() > 0;
+    }
+
+    void addSpuriousPacket(quic::OutstandingPacket pkt) {
+      spuriousPackets.emplace_back(pkt);
+    }
+    std::vector<quic::OutstandingPacket> spuriousPackets;
+  };
+
   virtual ~InstrumentationObserver() = default;
 
   /**
@@ -185,6 +200,17 @@ class InstrumentationObserver {
   virtual void pmtuUpperBoundDetected(
       QuicSocket*, /* socket */
       const PMTUUpperBoundEvent& /* pmtuUpperBoundEvent */) {}
+
+  /**
+   * spuriousPacketDetected() is invoked when an ACK from a lost packet
+   * arrives.
+   *
+   * @param socket   Socket when the callback is processed.
+   * @param packet   const reference to the lost packet.
+   */
+  virtual void spuriousPacketDetected(
+      QuicSocket*, /* socket */
+      const ObserverSpuriousLossEvent& /* lost packet */) {}
 };
 
 // Container for instrumentation observers.

--- a/quic/api/Observer.h
+++ b/quic/api/Observer.h
@@ -129,19 +129,19 @@ class InstrumentationObserver {
     ProbeSizeRaiserType probeSizeRaiserType;
   };
 
-  struct ObserverSpuriousLossEvent {
-    explicit ObserverSpuriousLossEvent(TimePoint rcvTimeIn)
+  struct SpuriousLossEvent {
+    explicit SpuriousLossEvent(const TimePoint rcvTimeIn = Clock::now())
         : rcvTime(rcvTimeIn) {}
-    TimePoint rcvTime;
 
     bool hasPackets() {
       return spuriousPackets.size() > 0;
     }
 
-    void addSpuriousPacket(quic::OutstandingPacket pkt) {
-      spuriousPackets.emplace_back(pkt);
+    void addSpuriousPacket(const quic::OutstandingPacket& pkt) {
+      spuriousPackets.emplace_back(pkt.lostByTimeout, pkt.lostByReorder, pkt);
     }
-    std::vector<quic::OutstandingPacket> spuriousPackets;
+    const TimePoint rcvTime;
+    std::vector<LostPacket> spuriousPackets;
   };
 
   virtual ~InstrumentationObserver() = default;
@@ -202,15 +202,15 @@ class InstrumentationObserver {
       const PMTUUpperBoundEvent& /* pmtuUpperBoundEvent */) {}
 
   /**
-   * spuriousPacketDetected() is invoked when an ACK from a lost packet
+   * spuriousLossDetected() is invoked when an ACK from a declared lost packet
    * arrives.
    *
    * @param socket   Socket when the callback is processed.
    * @param packet   const reference to the lost packet.
    */
-  virtual void spuriousPacketDetected(
+  virtual void spuriousLossDetected(
       QuicSocket*, /* socket */
-      const ObserverSpuriousLossEvent& /* lost packet */) {}
+      const SpuriousLossEvent& /* lost packet */) {}
 };
 
 // Container for instrumentation observers.

--- a/quic/api/test/Mocks.h
+++ b/quic/api/test/Mocks.h
@@ -354,8 +354,8 @@ class MockInstrumentationObserver : public InstrumentationObserver {
       ,
       noexcept,
       ,
-      spuriousPacketDetected,
-      void(QuicSocket*, const ObserverSpuriousLossEvent&));
+      spuriousLossDetected,
+      void(QuicSocket*, const SpuriousLossEvent&));
 
   static auto getLossPacketNum(PacketNum packetNum) {
     return testing::Field(

--- a/quic/api/test/Mocks.h
+++ b/quic/api/test/Mocks.h
@@ -350,15 +350,35 @@ class MockInstrumentationObserver : public InstrumentationObserver {
       ,
       pmtuUpperBoundDetected,
       void(QuicSocket*, const PMTUUpperBoundEvent&));
+  GMOCK_METHOD2_(
+      ,
+      noexcept,
+      ,
+      spuriousPacketDetected,
+      void(QuicSocket*, const ObserverSpuriousLossEvent&));
 
-  static auto getLossPacketMatcher(bool reorderLoss, bool timeoutLoss) {
+  static auto getLossPacketNum(PacketNum packetNum) {
+    return testing::Field(
+        &OutstandingPacket::packet,
+        testing::Field(
+            &RegularPacket::header,
+            testing::Property(&PacketHeader::getPacketSequenceNum, packetNum)));
+  }
+
+  static auto getLossPacketMatcher(
+      PacketNum packetNum,
+      bool reorderLoss,
+      bool timeoutLoss) {
     return AllOf(
         testing::Field(
             &InstrumentationObserver::LostPacket::lostByReorderThreshold,
             testing::Eq(reorderLoss)),
         testing::Field(
             &InstrumentationObserver::LostPacket::lostByTimeout,
-            testing::Eq(timeoutLoss)));
+            testing::Eq(timeoutLoss)),
+        testing::Field(
+            &InstrumentationObserver::LostPacket::packet,
+            getLossPacketNum(packetNum)));
   }
 };
 

--- a/quic/loss/QuicLossFunctions.h
+++ b/quic/loss/QuicLossFunctions.h
@@ -244,6 +244,8 @@ folly::Optional<CongestionController::LossEvent> detectLossPackets(
       if (!pkt.declaredLost) {
         ++conn.outstandings.declaredLostCount;
         pkt.declaredLost = true;
+        pkt.lostByTimeout = lostByTimeout;
+        pkt.lostByReorder = lostByReorder;
         ++conn.d6d.meta.totalLostProbes;
         if (currentPacketNum == conn.d6d.lastProbe->packetNum) {
           onD6DLastProbeLost(conn);
@@ -285,6 +287,8 @@ folly::Optional<CongestionController::LossEvent> detectLossPackets(
     // determine if this was spurious later.
     conn.outstandings.declaredLostCount++;
     iter->declaredLost = true;
+    iter->lostByTimeout = lostByTimeout;
+    iter->lostByReorder = lostByReorder;
     iter++;
   }
 

--- a/quic/loss/test/QuicLossFunctionsTest.cpp
+++ b/quic/loss/test/QuicLossFunctionsTest.cpp
@@ -132,9 +132,12 @@ class QuicLossFunctionsTest : public TestWithParam<PacketNumberSpace> {
   std::unique_ptr<MockQuicStats> transportInfoCb_;
   std::unique_ptr<ConnectionIdAlgo> connIdAlgo_;
 
-  auto getLossPacketMatcher(bool lossByReorder, bool lossByTimeout) {
+  auto getLossPacketMatcher(
+      PacketNum packetNum,
+      bool lossByReorder,
+      bool lossByTimeout) {
     return MockInstrumentationObserver::getLossPacketMatcher(
-        lossByReorder, lossByTimeout);
+        packetNum, lossByReorder, lossByTimeout);
   }
 };
 
@@ -1923,9 +1926,9 @@ TEST_F(QuicLossFunctionsTest, TestReorderLossObserverCallback) {
           Field(
               &InstrumentationObserver::ObserverLossEvent::lostPackets,
               UnorderedElementsAre(
-                  getLossPacketMatcher(true, false),
-                  getLossPacketMatcher(true, false),
-                  getLossPacketMatcher(true, false)))))
+                  getLossPacketMatcher(1, true, false),
+                  getLossPacketMatcher(2, true, false),
+                  getLossPacketMatcher(6, true, false)))))
       .Times(1);
 
   for (auto& callback : conn->pendingCallbacks) {
@@ -1976,13 +1979,13 @@ TEST_F(QuicLossFunctionsTest, TestTimeoutLossObserverCallback) {
           Field(
               &InstrumentationObserver::ObserverLossEvent::lostPackets,
               UnorderedElementsAre(
-                  getLossPacketMatcher(false, true),
-                  getLossPacketMatcher(false, true),
-                  getLossPacketMatcher(false, true),
-                  getLossPacketMatcher(false, true),
-                  getLossPacketMatcher(false, true),
-                  getLossPacketMatcher(false, true),
-                  getLossPacketMatcher(false, true)))))
+                  getLossPacketMatcher(1, false, true),
+                  getLossPacketMatcher(2, false, true),
+                  getLossPacketMatcher(3, false, true),
+                  getLossPacketMatcher(4, false, true),
+                  getLossPacketMatcher(5, false, true),
+                  getLossPacketMatcher(6, false, true),
+                  getLossPacketMatcher(7, false, true)))))
       .Times(1);
 
   for (auto& callback : conn->pendingCallbacks) {
@@ -2039,10 +2042,10 @@ TEST_F(QuicLossFunctionsTest, TestTimeoutAndReorderLossObserverCallback) {
           Field(
               &InstrumentationObserver::ObserverLossEvent::lostPackets,
               UnorderedElementsAre(
-                  getLossPacketMatcher(true, true),
-                  getLossPacketMatcher(true, true),
-                  getLossPacketMatcher(true, true),
-                  getLossPacketMatcher(false, true)))))
+                  getLossPacketMatcher(1, true, true),
+                  getLossPacketMatcher(2, true, true),
+                  getLossPacketMatcher(6, true, true),
+                  getLossPacketMatcher(7, false, true)))))
       .Times(1);
 
   for (auto& callback : conn->pendingCallbacks) {

--- a/quic/state/OutstandingPacket.h
+++ b/quic/state/OutstandingPacket.h
@@ -92,6 +92,12 @@ struct OutstandingPacket {
   // lost.
   bool declaredLost{false};
 
+  // True if packet was declared lost due to timeout.
+  bool lostByTimeout{false};
+
+  // True if packet was declared lost due to reordering.
+  bool lostByReorder{false};
+
   OutstandingPacket(
       RegularQuicWritePacket packetIn,
       TimePoint timeIn,

--- a/quic/state/test/AckHandlersTest.cpp
+++ b/quic/state/test/AckHandlersTest.cpp
@@ -36,6 +36,33 @@ auto testLossHandler(std::vector<PacketNum>& lostPackets) -> decltype(auto) {
   };
 }
 
+auto emplacePackets(
+    QuicServerConnectionState& conn,
+    PacketNum lastPacketNum,
+    TimePoint startTime,
+    PacketNumberSpace pnSpace) {
+  PacketNum packetNum = 0;
+  StreamId streamid = 0;
+  TimePoint sentTime;
+  std::vector<TimePoint> packetRcvTime;
+  while (packetNum < lastPacketNum) {
+    auto regularPacket = createNewPacket(packetNum, pnSpace);
+    WriteStreamFrame frame(streamid++, 0, 0, true);
+    regularPacket.frames.emplace_back(std::move(frame));
+    sentTime = startTime + std::chrono::milliseconds(packetNum);
+    packetRcvTime.emplace_back(sentTime);
+    OutstandingPacket sentPacket(
+        std::move(regularPacket),
+        sentTime,
+        1,
+        false /* handshake */,
+        packetNum,
+        packetNum + 1);
+    conn.outstandings.packets.emplace_back(sentPacket);
+    packetNum++;
+  }
+}
+
 TEST_P(AckHandlersTest, TestAckMultipleSequentialBlocks) {
   QuicServerConnectionState conn(
       FizzServerQuicHandshakeContext::Builder().build());
@@ -1220,6 +1247,180 @@ TEST_P(AckHandlersTest, TestRTTPacketObserverCallback) {
                         &quic::OutstandingPacketMetadata::inflightBytes,
                         ackData.endSeq + 1)))));
   }
+
+  for (auto& callback : conn.pendingCallbacks) {
+    callback(nullptr);
+  }
+}
+
+TEST_P(AckHandlersTest, TestSpuriousObserverReorder) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  auto mockCongestionController = std::make_unique<MockCongestionController>();
+  conn.congestionController = std::move(mockCongestionController);
+
+  // Register 1 instrumentation observer
+  auto ib = MockInstrumentationObserver();
+  conn.instrumentationObservers_.emplace_back(&ib);
+  auto noopLossVisitor = [](auto&, auto&, bool) {};
+
+  TimePoint startTime = Clock::now();
+  emplacePackets(conn, 10, startTime, GetParam());
+
+  // from [0, 9], [3, 4] already acked
+  auto beginPacket = getFirstOutstandingPacket(conn, GetParam());
+  conn.outstandings.packets.erase(beginPacket + 3, beginPacket + 5);
+
+  // setting a very low reordering threshold to force loss by reorder
+  conn.lossState.reorderingThreshold = 1;
+  // setting time out parameters higher than the time at which detectLossPackets
+  // is called to make sure there are no losses by timeout
+  conn.lossState.srtt = 400ms;
+  conn.lossState.lrtt = 350ms;
+  conn.transportSettings.timeReorderingThreshDividend = 1.0;
+  conn.transportSettings.timeReorderingThreshDivisor = 1.0;
+  TimePoint checkTime = startTime + 20ms;
+
+  detectLossPackets(conn, 4, noopLossVisitor, checkTime, GetParam());
+
+  // expecting 1 callback to be stacked
+  EXPECT_EQ(1, size(conn.pendingCallbacks));
+
+  EXPECT_CALL(
+      ib,
+      packetLossDetected(
+          nullptr,
+          Field(
+              &InstrumentationObserver::ObserverLossEvent::lostPackets,
+              UnorderedElementsAre(
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      0, true, false),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      1, true, false),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      2, true, false)))))
+      .Times(1);
+
+  // Here we receive the spurious loss packets in a late ack
+  {
+    ReadAckFrame ackFrame;
+    ackFrame.largestAcked = 2;
+    ackFrame.ackBlocks.emplace_back(0, 2);
+
+    processAckFrame(
+        conn,
+        GetParam(),
+        ackFrame,
+        [](const auto&, const auto&, const auto&) {},
+        [](auto&, auto&, bool) {},
+        startTime + 30ms);
+  }
+
+  // Spurious loss observer call added
+  EXPECT_EQ(2, size(conn.pendingCallbacks));
+
+  EXPECT_CALL(
+      ib,
+      spuriousPacketDetected(
+          nullptr,
+          Field(
+              &InstrumentationObserver::ObserverSpuriousLossEvent::
+                  spuriousPackets,
+              UnorderedElementsAre(
+                  MockInstrumentationObserver::getLossPacketNum(0),
+                  MockInstrumentationObserver::getLossPacketNum(1),
+                  MockInstrumentationObserver::getLossPacketNum(2)))))
+      .Times(1);
+
+  for (auto& callback : conn.pendingCallbacks) {
+    callback(nullptr);
+  }
+}
+
+TEST_P(AckHandlersTest, TestSpuriousObserverTimeout) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  auto mockCongestionController = std::make_unique<MockCongestionController>();
+  conn.congestionController = std::move(mockCongestionController);
+
+  // Register 1 instrumentation observer
+  auto ib = MockInstrumentationObserver();
+  conn.instrumentationObservers_.emplace_back(&ib);
+  auto noopLossVisitor = [](auto&, auto&, bool) {};
+
+  TimePoint startTime = Clock::now();
+  emplacePackets(conn, 10, startTime, GetParam());
+
+  // from [0, 9], [0, 4] already acked
+  auto beginPacket = getFirstOutstandingPacket(conn, GetParam());
+  conn.outstandings.packets.erase(beginPacket, beginPacket + 5);
+
+  // setting a very high reordering threshold to force loss by timeout only
+  conn.lossState.reorderingThreshold = 100;
+  // setting time out parameters lower than the time at which detectLossPackets
+  // is called to make sure all packets timeout
+  conn.lossState.srtt = 400ms;
+  conn.lossState.lrtt = 350ms;
+  conn.transportSettings.timeReorderingThreshDividend = 1.0;
+  conn.transportSettings.timeReorderingThreshDivisor = 1.0;
+  TimePoint checkTime = startTime + 500ms;
+
+  detectLossPackets(conn, 10, noopLossVisitor, checkTime, GetParam());
+
+  // expecting 1 callback to be stacked
+  EXPECT_EQ(1, size(conn.pendingCallbacks));
+
+  EXPECT_CALL(
+      ib,
+      packetLossDetected(
+          nullptr,
+          Field(
+              &InstrumentationObserver::ObserverLossEvent::lostPackets,
+              UnorderedElementsAre(
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      5, false, true),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      6, false, true),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      7, false, true),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      8, false, true),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      9, false, true)))))
+      .Times(1);
+
+  // Here we receive the spurious loss packets in a late ack
+  {
+    ReadAckFrame ackFrame;
+    ackFrame.largestAcked = 9;
+    ackFrame.ackBlocks.emplace_back(5, 9);
+
+    processAckFrame(
+        conn,
+        GetParam(),
+        ackFrame,
+        [](const auto&, const auto&, const auto&) {},
+        [](auto&, auto&, bool) {},
+        startTime + 510ms);
+  }
+
+  // Spurious loss observer call added
+  EXPECT_EQ(2, size(conn.pendingCallbacks));
+
+  EXPECT_CALL(
+      ib,
+      spuriousPacketDetected(
+          nullptr,
+          Field(
+              &InstrumentationObserver::ObserverSpuriousLossEvent::
+                  spuriousPackets,
+              UnorderedElementsAre(
+                  MockInstrumentationObserver::getLossPacketNum(5),
+                  MockInstrumentationObserver::getLossPacketNum(6),
+                  MockInstrumentationObserver::getLossPacketNum(7),
+                  MockInstrumentationObserver::getLossPacketNum(8),
+                  MockInstrumentationObserver::getLossPacketNum(9)))))
+      .Times(1);
 
   for (auto& callback : conn.pendingCallbacks) {
     callback(nullptr);

--- a/quic/state/test/AckHandlersTest.cpp
+++ b/quic/state/test/AckHandlersTest.cpp
@@ -1321,15 +1321,17 @@ TEST_P(AckHandlersTest, TestSpuriousObserverReorder) {
 
   EXPECT_CALL(
       ib,
-      spuriousPacketDetected(
+      spuriousLossDetected(
           nullptr,
           Field(
-              &InstrumentationObserver::ObserverSpuriousLossEvent::
-                  spuriousPackets,
+              &InstrumentationObserver::SpuriousLossEvent::spuriousPackets,
               UnorderedElementsAre(
-                  MockInstrumentationObserver::getLossPacketNum(0),
-                  MockInstrumentationObserver::getLossPacketNum(1),
-                  MockInstrumentationObserver::getLossPacketNum(2)))))
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      0, true, false),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      1, true, false),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      2, true, false)))))
       .Times(1);
 
   for (auto& callback : conn.pendingCallbacks) {
@@ -1409,17 +1411,21 @@ TEST_P(AckHandlersTest, TestSpuriousObserverTimeout) {
 
   EXPECT_CALL(
       ib,
-      spuriousPacketDetected(
+      spuriousLossDetected(
           nullptr,
           Field(
-              &InstrumentationObserver::ObserverSpuriousLossEvent::
-                  spuriousPackets,
+              &InstrumentationObserver::SpuriousLossEvent::spuriousPackets,
               UnorderedElementsAre(
-                  MockInstrumentationObserver::getLossPacketNum(5),
-                  MockInstrumentationObserver::getLossPacketNum(6),
-                  MockInstrumentationObserver::getLossPacketNum(7),
-                  MockInstrumentationObserver::getLossPacketNum(8),
-                  MockInstrumentationObserver::getLossPacketNum(9)))))
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      5, false, true),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      6, false, true),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      7, false, true),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      8, false, true),
+                  MockInstrumentationObserver::getLossPacketMatcher(
+                      9, false, true)))))
       .Times(1);
 
   for (auto& callback : conn.pendingCallbacks) {


### PR DESCRIPTION
Summary:
Extended instrumentationObserver to record packets that were spuriously lost due to reordering or timeout.

Depends on #185 