### PR TITLE
Copa2, a new congestion control algorithm

### DIFF
--- a/QUIC_TRACE_FORMAT.md
+++ b/QUIC_TRACE_FORMAT.md
@@ -30,6 +30,8 @@ reltime ||    client_conn_id ||     server_conn_id ||     event ||              
 | conn_close | Drain, SendCloseFrame, CloseReason, Error | |
 | copa_ack | CwndBytes, InflightBytes | |
 | copa_loss | CwndBytes, InflightBytes | |
+| copa2_ack | CwndBytes, InflightBytes | |
+| copa2_loss | CwndBytes, InflightBytes | |
 | cubic_appidle | IsAppIdle, EventTimeSinceEpoch, LastCwndReductionTimeSinceEpoch | |
 | cubic_ack | CubicState, CwndBytes, InflightBytes, LastMaxCwndBytes | |
 | cubic_loss | CubicState, CwndBytes, InflightBytes, LastMaxCwndBytes | |

--- a/quic/QuicConstants.cpp
+++ b/quic/QuicConstants.cpp
@@ -18,6 +18,8 @@ folly::StringPiece congestionControlTypeToString(CongestionControlType type) {
       return kCongestionControlBbrStr;
     case CongestionControlType::Copa:
       return kCongestionControlCopaStr;
+    case CongestionControlType::Copa2:
+      return kCongestionControlCopa2Str;
     case CongestionControlType::NewReno:
       return kCongestionControlNewRenoStr;
     case CongestionControlType::None:
@@ -37,6 +39,8 @@ folly::Optional<CongestionControlType> congestionControlStrToType(
     return quic::CongestionControlType::BBR;
   } else if (str == kCongestionControlCopaStr) {
     return quic::CongestionControlType::Copa;
+  } else if (str == kCongestionControlCopa2Str) {
+    return quic::CongestionControlType::Copa2;
   } else if (str == kCongestionControlNewRenoStr) {
     return quic::CongestionControlType::NewReno;
   } else if (str == kCongestionControlNoneStr) {

--- a/quic/QuicConstants.h
+++ b/quic/QuicConstants.h
@@ -330,6 +330,7 @@ constexpr DurationRep kDefaultWriteLimitRttFraction = 25;
 constexpr folly::StringPiece kCongestionControlCubicStr = "cubic";
 constexpr folly::StringPiece kCongestionControlBbrStr = "bbr";
 constexpr folly::StringPiece kCongestionControlCopaStr = "copa";
+constexpr folly::StringPiece kCongestionControlCopa2Str = "copa2";
 constexpr folly::StringPiece kCongestionControlNewRenoStr = "newreno";
 constexpr folly::StringPiece kCongestionControlNoneStr = "none";
 constexpr folly::StringPiece kCongestionControlCcpStr = "ccp";
@@ -339,6 +340,7 @@ enum class CongestionControlType : uint8_t {
   Cubic,
   NewReno,
   Copa,
+  Copa2,
   BBR,
   CCP,
   None

--- a/quic/congestion_control/CMakeLists.txt
+++ b/quic/congestion_control/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
   CongestionControlFunctions.cpp
   CongestionControllerFactory.cpp
   Copa.cpp
+  Copa2.cpp
   NewReno.cpp
   QuicCubic.cpp
   QuicCCP.cpp

--- a/quic/congestion_control/CongestionControllerFactory.cpp
+++ b/quic/congestion_control/CongestionControllerFactory.cpp
@@ -12,6 +12,7 @@
 #include <quic/congestion_control/BbrBandwidthSampler.h>
 #include <quic/congestion_control/BbrRttSampler.h>
 #include <quic/congestion_control/Copa.h>
+#include <quic/congestion_control/Copa2.h>
 #include <quic/congestion_control/NewReno.h>
 #include <quic/congestion_control/QuicCubic.h>
 
@@ -32,6 +33,9 @@ DefaultCongestionControllerFactory::makeCongestionController(
       break;
     case CongestionControlType::Copa:
       congestionController = std::make_unique<Copa>(conn);
+      break;
+    case CongestionControlType::Copa2:
+      congestionController = std::make_unique<Copa2>(conn);
       break;
     case CongestionControlType::BBR: {
       auto bbr = std::make_unique<BbrCongestionController>(conn);

--- a/quic/congestion_control/Copa2.cpp
+++ b/quic/congestion_control/Copa2.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#include <quic/congestion_control/Copa2.h>
+#include <quic/congestion_control/CongestionControlFunctions.h>
+#include <quic/logging/QLoggerConstants.h>
+#include <quic/logging/QuicLogger.h>
+
+namespace quic {
+
+using namespace std::chrono;
+
+Copa2::Copa2(QuicConnectionStateBase& conn)
+    : conn_(conn),
+      cwndBytes_(conn.transportSettings.initCwndInMss * conn.udpSendPacketLen),
+      minRTTFilter_(kCopa2MinRttWindowLength.count(), 0us, 0) {
+  VLOG(10) << __func__ << " writable=" << Copa2::getWritableBytes()
+           << " cwnd=" << cwndBytes_
+           << " inflight=" << conn_.lossState.inflightBytes << " " << conn_;
+  QUIC_TRACE(initcwnd, conn_, cwndBytes_);
+}
+
+void Copa2::onRemoveBytesFromInflight(uint64_t bytes) {
+  subtractAndCheckUnderflow(conn_.lossState.inflightBytes, bytes);
+  VLOG(10) << __func__ << " writable=" << getWritableBytes()
+           << " cwnd=" << cwndBytes_
+           << " inflight=" << conn_.lossState.inflightBytes << " " << conn_;
+  if (conn_.qLogger) {
+    conn_.qLogger->addCongestionMetricUpdate(
+        conn_.lossState.inflightBytes, getCongestionWindow(), kRemoveInflight);
+  }
+}
+
+void Copa2::onPacketSent(const OutstandingPacket& packet) {
+  addAndCheckOverflow(
+      conn_.lossState.inflightBytes, packet.metadata.encodedSize);
+
+  VLOG(10) << __func__ << " writable=" << getWritableBytes()
+           << " cwnd=" << cwndBytes_
+           << " inflight=" << conn_.lossState.inflightBytes
+           << " bytesBufferred=" << conn_.flowControlState.sumCurStreamBufferLen
+           << " packetNum=" << packet.packet.header.getPacketSequenceNum()
+           << " " << conn_;
+  if (conn_.qLogger) {
+    conn_.qLogger->addCongestionMetricUpdate(
+        conn_.lossState.inflightBytes,
+        getCongestionWindow(),
+        kCongestionPacketSent);
+  }
+}
+
+void Copa2::onPacketAckOrLoss(
+    folly::Optional<AckEvent> ack,
+    folly::Optional<LossEvent> loss) {
+  if (loss) {
+    onPacketLoss(*loss);
+    if (conn_.pacer) {
+      conn_.pacer->onPacketsLoss();
+    }
+    QUIC_TRACE(copa2_loss, conn_, cwndBytes_, conn_.lossState.inflightBytes);
+  }
+  if (ack && ack->largestAckedPacket.has_value()) {
+    onPacketAcked(*ack);
+    QUIC_TRACE(copa2_ack, conn_, cwndBytes_, conn_.lossState.inflightBytes);
+  }
+}
+
+// Switch to and from lossy mode
+void Copa2::manageLossyMode(folly::Optional<TimePoint> sentTime) {
+  if (!sentTime) {
+    // Loss happened and we don't know when. Be safe
+    lossyMode_ = true;
+    numAckedInLossCycle_ = 0;
+    numLostInLossCycle_ = 0;
+    lossCycleStartTime_ = Clock::now();
+    return;
+  }
+
+  auto numPktsInLossCycle = numAckedInLossCycle_ + numLostInLossCycle_;
+  if (*sentTime < lossCycleStartTime_) {
+    // Wait for at-least one RTT before declaring lossyMode_
+    return;
+  }
+  if (numPktsInLossCycle < 2 / lossToleranceParam_ && numLostInLossCycle_ < 2) {
+    // Second condition is needed in case there are losses, but not acks
+    return;
+  }
+  VLOG(5) << __func__ << " lossyMode=" << lossyMode_
+          << " num lost=" << numLostInLossCycle_
+          << " num acked=" << numAckedInLossCycle_ << " " << conn_;
+  // Cycle has ended. Take stock of the situation
+  DCHECK(numPktsInLossCycle > 0);
+  lossyMode_ = numLostInLossCycle_ >= numPktsInLossCycle * lossToleranceParam_;
+  numAckedInLossCycle_ = 0;
+  numLostInLossCycle_ = 0;
+  lossCycleStartTime_ = Clock::now();
+}
+
+void Copa2::onPacketLoss(const LossEvent& loss) {
+  VLOG(10) << __func__ << " lostBytes=" << loss.lostBytes
+           << " lostPackets=" << loss.lostPackets << " cwnd=" << cwndBytes_
+           << " inflight=" << conn_.lossState.inflightBytes << " " << conn_;
+  if (conn_.qLogger) {
+    conn_.qLogger->addCongestionMetricUpdate(
+        conn_.lossState.inflightBytes,
+        getCongestionWindow(),
+        kCongestionPacketLoss);
+  }
+  DCHECK(loss.largestLostPacketNum.has_value());
+  subtractAndCheckUnderflow(conn_.lossState.inflightBytes, loss.lostBytes);
+  if (loss.persistentCongestion) {
+    VLOG(10) << __func__ << " writable=" << getWritableBytes()
+             << " cwnd=" << cwndBytes_
+             << " inflight=" << conn_.lossState.inflightBytes << " " << conn_;
+    cwndBytes_ = conn_.transportSettings.minCwndInMss * conn_.udpSendPacketLen;
+    if (conn_.pacer) {
+      // TODO Which min RTT should we use?
+      conn_.pacer->refreshPacingRate(cwndBytes_, conn_.lossState.mrtt);
+    }
+    if (conn_.qLogger) {
+      conn_.qLogger->addCongestionMetricUpdate(
+          conn_.lossState.inflightBytes,
+          getCongestionWindow(),
+          kPersistentCongestion);
+    }
+  }
+
+  numLostInLossCycle_ += loss.lostPackets;
+  manageLossyMode(loss.largestLostSentTime);
+}
+
+void Copa2::onPacketAcked(const AckEvent& ack) {
+  DCHECK(ack.largestAckedPacket.has_value());
+  subtractAndCheckUnderflow(conn_.lossState.inflightBytes, ack.ackedBytes);
+  minRTTFilter_.Update(
+      conn_.lossState.lrtt,
+      std::chrono::duration_cast<microseconds>(ack.ackTime.time_since_epoch())
+          .count());
+  bytesAckedInCycle_ += ack.ackedBytes;
+  for (const auto& ackPkt : ack.ackedPackets) {
+    appLimitedInCycle_ = appLimitedInCycle_ || ackPkt.isAppLimited;
+  }
+  auto rttMin = minRTTFilter_.GetBest();
+
+  numAckedInLossCycle_ += ack.ackedPackets.size();
+  manageLossyMode(ack.largestAckedPacketSentTime);
+
+  auto dParam = rttMin;
+  if (lossyMode_) {
+    // Looks like a short buffer. Let's become less aggressive
+    dParam = duration_cast<microseconds>(rttMin * 2. * lossToleranceParam_);
+  }
+  // The duration over which we calculate the number of bytes acked
+  auto cycleDur = rttMin + dParam;
+
+  if (probeRtt_) {
+    // Do we exit probe RTT now?
+    if (lastProbeRtt_ + dParam <= ack.ackTime) {
+      // Note, probe rtt should ideally never decrease ack rate, since
+      // it just barely empties the queue. Hence all ack rate samples
+      // are good independent of whether we probed for rtt
+      probeRtt_ = false;
+    }
+  } else {
+    // See if we need to enter probe rtt mode
+    auto interval = kCopa2ProbeRttInterval / (conn_.lossState.lrtt < rttMin + dParam ? 2 : 1);
+    if (lastProbeRtt_ + interval <= ack.ackTime) {
+      probeRtt_ = true;
+      lastProbeRtt_ = ack.ackTime;
+    }
+  }
+
+  if (!cycleStartTime_) {
+    cycleStartTime_ = ack.ackTime;
+    return;
+  }
+
+  // See if cycle needs to be continued
+  if (*cycleStartTime_ + cycleDur > ack.ackTime) {
+    return;
+  }
+
+  // Cycle has ended. Update cwnd and rate
+  auto newCwnd = bytesAckedInCycle_ + alphaParam_ * conn_.udpSendPacketLen;
+  if (!appLimitedInCycle_ || cwndBytes_ < newCwnd) {
+    // If CC was app limited, don't decrease cwnd
+    cwndBytes_ = newCwnd;
+  }
+
+  auto minCwnd = conn_.transportSettings.minCwndInMss * conn_.udpSendPacketLen;
+  if (probeRtt_ || cwndBytes_ < minCwnd) {
+    cwndBytes_ = minCwnd;
+  }
+  if (conn_.pacer) {
+    conn_.pacer->refreshPacingRate(cwndBytes_, rttMin);
+  }
+
+  VLOG(5) << __func__ << "updated cwnd=" << cwndBytes_
+          << " rttMin=" << rttMin.count()
+          << " lrtt=" << conn_.lossState.lrtt.count()
+          << " dParam=" << dParam.count() << " " << conn_;
+
+  cycleStartTime_ = ack.ackTime;
+  bytesAckedInCycle_ = 0;
+  appLimitedInCycle_ = false;
+}
+
+uint64_t Copa2::getWritableBytes() const noexcept {
+  if (conn_.lossState.inflightBytes > cwndBytes_) {
+    return 0;
+  } else {
+    return cwndBytes_ - conn_.lossState.inflightBytes;
+  }
+}
+
+uint64_t Copa2::getCongestionWindow() const noexcept {
+  return cwndBytes_;
+}
+
+CongestionControlType Copa2::type() const noexcept {
+  return CongestionControlType::Copa2;
+}
+
+bool Copa2::inLossyMode() const noexcept {
+  return lossyMode_;
+}
+
+bool Copa2::inProbeRtt() const noexcept {
+  return probeRtt_;
+}
+
+uint64_t Copa2::getBytesInFlight() const noexcept {
+  return conn_.lossState.inflightBytes;
+}
+
+void Copa2::setAppIdle(bool, TimePoint) noexcept { /* unsupported */
+}
+
+void Copa2::setAppLimited() { /* unsupported */
+}
+
+bool Copa2::isAppLimited() const noexcept {
+  return false; // not supported
+}
+
+void Copa2::getStats(CongestionControllerStats& stats) const {}
+
+} // namespace quic

--- a/quic/congestion_control/Copa2.h
+++ b/quic/congestion_control/Copa2.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#pragma once
+
+#include <quic/congestion_control/third_party/windowed_filter.h>
+#include <quic/state/StateData.h>
+
+namespace quic {
+
+using namespace std::chrono_literals;
+constexpr std::chrono::microseconds kCopa2MinRttWindowLength{10s};
+constexpr std::chrono::microseconds kCopa2ProbeRttInterval{8s};
+
+class Copa2 : public CongestionController {
+ public:
+  explicit Copa2(QuicConnectionStateBase& conn);
+  void onRemoveBytesFromInflight(uint64_t) override;
+  void onPacketSent(const OutstandingPacket& packet) override;
+  void onPacketAckOrLoss(folly::Optional<AckEvent>, folly::Optional<LossEvent>)
+      override;
+
+  FOLLY_NODISCARD uint64_t getWritableBytes() const noexcept override;
+  FOLLY_NODISCARD uint64_t getCongestionWindow() const noexcept override;
+  FOLLY_NODISCARD CongestionControlType type() const noexcept override;
+
+  void setAppIdle(bool, TimePoint) noexcept override;
+  void setAppLimited() override;
+  FOLLY_NODISCARD bool isAppLimited() const noexcept override;
+
+  FOLLY_NODISCARD bool inLossyMode() const noexcept;
+  FOLLY_NODISCARD bool inProbeRtt() const noexcept;
+  FOLLY_NODISCARD uint64_t getBytesInFlight() const noexcept;
+
+  void getStats(CongestionControllerStats& stats) const override;
+
+ private:
+  void onPacketLoss(const LossEvent&);
+  void onPacketAcked(const AckEvent&);
+  void manageLossyMode(folly::Optional<TimePoint> sentTime);
+
+  QuicConnectionStateBase& conn_;
+  uint64_t cwndBytes_;
+
+  // In packets
+  uint64_t alphaParam_{10};
+  // Loss rate we are willing to tolerate. Actual loss rate will be 2 *
+  // lossTolaranceParam_ + alpha/BDP
+  double lossToleranceParam_{0.05};
+
+  // To get the min RTT over 10 seconds
+  WindowedFilter<
+      std::chrono::microseconds,
+      MinFilter<std::chrono::microseconds>,
+      uint64_t,
+      uint64_t>
+      minRTTFilter_;
+
+  // Updates happen in cycles.
+  folly::Optional<TimePoint> cycleStartTime_;
+  bool appLimitedInCycle_{false};
+  uint64_t bytesAckedInCycle_{0};
+
+  // We calculate loss rates over enough time that we can get a
+  // reliable estimate. We ensure the period includes at-least 1 RTT
+  // and an opportunity to lose 2 packets and still exceed the loss tolerance
+  uint64_t numAckedInLossCycle_{0};
+  uint64_t numLostInLossCycle_{0};
+  TimePoint lossCycleStartTime_{Clock::now()};
+  bool lossyMode_{false};
+
+  // Whether we are currently in probe RTT
+  bool probeRtt_{false};
+  // Last time we entered probe RTT
+  TimePoint lastProbeRtt_{Clock::now()};
+};
+
+} // namespace quic

--- a/quic/congestion_control/ServerCongestionControllerFactory.cpp
+++ b/quic/congestion_control/ServerCongestionControllerFactory.cpp
@@ -12,6 +12,7 @@
 #include <quic/congestion_control/BbrBandwidthSampler.h>
 #include <quic/congestion_control/BbrRttSampler.h>
 #include <quic/congestion_control/Copa.h>
+#include <quic/congestion_control/Copa2.h>
 #include <quic/congestion_control/NewReno.h>
 #include <quic/congestion_control/QuicCCP.h>
 #include <quic/congestion_control/QuicCubic.h>
@@ -33,6 +34,9 @@ ServerCongestionControllerFactory::makeCongestionController(
       break;
     case CongestionControlType::Copa:
       congestionController = std::make_unique<Copa>(conn);
+      break;
+    case CongestionControlType::Copa2:
+      congestionController = std::make_unique<Copa2>(conn);
       break;
     case CongestionControlType::BBR: {
       auto bbr = std::make_unique<BbrCongestionController>(conn);

--- a/quic/congestion_control/test/Copa2Test.cpp
+++ b/quic/congestion_control/test/Copa2Test.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#include <quic/congestion_control/Copa2.h>
+
+#include <folly/portability/GTest.h>
+#include <quic/common/test/TestUtils.h>
+#include <quic/fizz/server/handshake/FizzServerQuicHandshakeContext.h>
+#include <quic/state/test/Mocks.h>
+
+using namespace testing;
+
+namespace quic::test {
+
+class Copa2Test : public Test {
+ public:
+  OutstandingPacket createPacket(
+      PacketNum packetNum,
+      uint32_t size,
+      uint64_t totalSent,
+      uint64_t inflight = 0) {
+    auto connId = getTestConnectionId();
+    RegularQuicWritePacket packet(
+        ShortHeader(ProtectionType::KeyPhaseZero, connId, packetNum));
+    return OutstandingPacket(
+        std::move(packet), Clock::now(), size, false, totalSent, inflight);
+  }
+
+  CongestionController::AckEvent createAckEvent(
+      PacketNum largestAcked,
+      uint64_t ackedSize,
+      TimePoint ackTime) {
+    CongestionController::AckEvent ack;
+    ack.largestAckedPacket = largestAcked;
+    ack.ackTime = ackTime;
+    ack.ackedBytes = ackedSize;
+    ack.ackedPackets.push_back(makeAckPacketFromOutstandingPacket(createPacket(
+        largestAcked,
+        ackedSize,
+        ackedSize /* incorrect totalSent but works for this test */)));
+    return ack;
+  }
+};
+
+TEST_F(Copa2Test, TestWritableBytes) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  Copa2 copa2(conn);
+  EXPECT_FALSE(copa2.inLossyMode());
+  EXPECT_FALSE(copa2.inProbeRtt());
+
+  conn.lossState.largestSent = 5;
+  PacketNum ackPacketNum = 6;
+  uint64_t writableBytes = copa2.getWritableBytes();
+  copa2.onPacketSent(
+      createPacket(ackPacketNum, writableBytes - 10, writableBytes - 10));
+  EXPECT_EQ(copa2.getWritableBytes(), 10);
+  copa2.onPacketSent(createPacket(ackPacketNum, 20, writableBytes + 10));
+  EXPECT_EQ(copa2.getWritableBytes(), 0);
+}
+
+TEST_F(Copa2Test, PersistentCongestion) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  Copa2 copa2(conn);
+  auto qLogger = std::make_shared<FileQLogger>(VantagePoint::Client);
+  conn.qLogger = qLogger;
+  EXPECT_FALSE(copa2.inLossyMode());
+  EXPECT_FALSE(copa2.inProbeRtt());
+
+  conn.lossState.largestSent = 5;
+  PacketNum ackPacketNum = 6;
+  uint32_t ackedSize = 10;
+  uint64_t writableBytes = copa2.getWritableBytes();
+  auto pkt = createPacket(ackPacketNum, ackedSize, ackedSize);
+  copa2.onPacketSent(pkt);
+  EXPECT_EQ(copa2.getWritableBytes(), writableBytes - ackedSize);
+
+  CongestionController::LossEvent loss;
+  loss.persistentCongestion = true;
+  loss.addLostPacket(pkt);
+  copa2.onPacketAckOrLoss(folly::none, loss);
+  EXPECT_EQ(
+      copa2.getCongestionWindow(),
+      conn.transportSettings.minCwndInMss * conn.udpSendPacketLen);
+  EXPECT_FALSE(copa2.inLossyMode());
+
+  std::vector<int> indices =
+      getQLogEventIndices(QLogEventType::CongestionMetricUpdate, qLogger);
+  EXPECT_EQ(indices.size(), 3);
+  auto tmp = std::move(qLogger->logs[indices[0]]);
+  auto event = dynamic_cast<QLogCongestionMetricUpdateEvent*>(tmp.get());
+  EXPECT_EQ(event->bytesInFlight, 10);
+  EXPECT_EQ(event->currentCwnd, kDefaultCwnd);
+  EXPECT_EQ(event->congestionEvent, kCongestionPacketSent);
+}
+
+TEST_F(Copa2Test, RemoveBytesWithoutLossOrAck) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  Copa2 copa2(conn);
+  auto qLogger = std::make_shared<FileQLogger>(VantagePoint::Client);
+  conn.qLogger = qLogger;
+
+  auto originalWritableBytes = copa2.getWritableBytes();
+  conn.lossState.largestSent = 5;
+  PacketNum ackPacketNum = 6;
+  uint32_t ackedSize = 10;
+  copa2.onPacketSent(createPacket(ackPacketNum, ackedSize, ackedSize));
+  copa2.onRemoveBytesFromInflight(2);
+  EXPECT_EQ(copa2.getWritableBytes(), originalWritableBytes - ackedSize + 2);
+
+  std::vector<int> indices =
+      getQLogEventIndices(QLogEventType::CongestionMetricUpdate, qLogger);
+  EXPECT_EQ(indices.size(), 2);
+  auto tmp = std::move(qLogger->logs[indices[0]]);
+  auto event = dynamic_cast<QLogCongestionMetricUpdateEvent*>(tmp.get());
+  EXPECT_EQ(event->bytesInFlight, ackedSize);
+  EXPECT_EQ(event->currentCwnd, kDefaultCwnd);
+  EXPECT_EQ(event->congestionEvent, kCongestionPacketSent);
+
+  auto tmp2 = std::move(qLogger->logs[indices[1]]);
+  auto event2 = dynamic_cast<QLogCongestionMetricUpdateEvent*>(tmp2.get());
+  EXPECT_EQ(event2->bytesInFlight, ackedSize - 2);
+  EXPECT_EQ(event2->currentCwnd, kDefaultCwnd);
+  EXPECT_EQ(event2->congestionEvent, kRemoveInflight);
+}
+
+TEST_F(Copa2Test, TestBwEstimate) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  // tests assume we sent at least 10 packets in the initial burst
+  Copa2 copa2(conn);
+  // initial cwnd = 10 packets
+  EXPECT_EQ(
+      copa2.getCongestionWindow(),
+      conn.transportSettings.initCwndInMss * conn.udpSendPacketLen);
+
+  auto numPacketsInFlight = 0;
+  auto packetNumToSend = 1;
+  auto packetSize = conn.udpSendPacketLen;
+  auto alphaParam = 10;
+  auto now = Clock::now();
+
+  uint64_t totalSent = 0;
+  // send one cwnd worth packets in a burst
+  conn.lossState.lrtt = 100ms;
+  while (copa2.getWritableBytes() > 0) {
+    totalSent += packetSize;
+    copa2.onPacketSent(createPacket(packetNumToSend, packetSize, totalSent));
+    numPacketsInFlight++;
+    EXPECT_EQ(copa2.getBytesInFlight(), numPacketsInFlight * packetSize);
+  }
+
+  // You get the ack for the first 5 packets after 100ms all at once
+  conn.lossState.lrtt = 100ms;
+  now += 100ms;
+  copa2.onPacketAckOrLoss(createAckEvent(5, 5 * packetSize, now), folly::none);
+  numPacketsInFlight -= 5;
+  EXPECT_EQ(copa2.getBytesInFlight(), numPacketsInFlight * packetSize);
+  // Not enough time has passed for cwnd to increase
+  EXPECT_EQ(
+      copa2.getCongestionWindow(),
+      conn.transportSettings.initCwndInMss * conn.udpSendPacketLen);
+
+  // We get one packet 210ms after that. Now cwnd will be updated
+  now += 210ms;
+  conn.lossState.lrtt = 500ms; // Large value should be ignored since
+                               // only the min rtt should matter.
+  copa2.onPacketAckOrLoss(createAckEvent(1, packetSize, now), folly::none);
+  EXPECT_EQ(
+      copa2.getCongestionWindow(), (6 + alphaParam) * conn.udpSendPacketLen);
+  EXPECT_FALSE(copa2.inLossyMode());
+  EXPECT_FALSE(copa2.inProbeRtt());
+}
+
+TEST_F(Copa2Test, NoLargestAckedPacketNoCrash) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  Copa2 copa2(conn);
+  auto qLogger = std::make_shared<FileQLogger>(VantagePoint::Client);
+  conn.qLogger = qLogger;
+  CongestionController::LossEvent loss;
+  loss.largestLostPacketNum = 0;
+  CongestionController::AckEvent ack;
+  copa2.onPacketAckOrLoss(ack, loss);
+
+  std::vector<int> indices =
+      getQLogEventIndices(QLogEventType::CongestionMetricUpdate, qLogger);
+  EXPECT_EQ(indices.size(), 1);
+  auto tmp = std::move(qLogger->logs[indices[0]]);
+  auto event = dynamic_cast<QLogCongestionMetricUpdateEvent*>(tmp.get());
+  EXPECT_EQ(event->bytesInFlight, copa2.getBytesInFlight());
+  EXPECT_EQ(event->currentCwnd, kDefaultCwnd);
+  EXPECT_EQ(event->congestionEvent, kCongestionPacketLoss);
+}
+
+TEST_F(Copa2Test, PacketLossInvokesPacer) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  Copa2 copa2(conn);
+  auto mockPacer = std::make_unique<MockPacer>();
+  auto rawPacer = mockPacer.get();
+  conn.pacer = std::move(mockPacer);
+  auto packet = createPacket(0, 1000, 1000);
+  copa2.onPacketSent(packet);
+  EXPECT_CALL(*rawPacer, onPacketsLoss()).Times(1);
+  CongestionController::LossEvent lossEvent;
+  lossEvent.addLostPacket(packet);
+  copa2.onPacketAckOrLoss(folly::none, lossEvent);
+  // Ack one packet to test how we set pacing rate
+  copa2.onPacketSent(createPacket(1, 1000, 2000));
+  copa2.onPacketAckOrLoss(createAckEvent(1, 1000, Clock::now()), folly::none);
+}
+
+TEST_F(Copa2Test, ProbeRttHappens) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  conn.transportSettings.initCwndInMss = 10;
+  Copa2 copa2(conn);
+  auto now = Clock::now();
+  auto packetSize = conn.udpSendPacketLen;
+  uint64_t totalSent = 0;
+  auto packetNumToSend = 1;
+  conn.lossState.lrtt = 100ms;
+  while (copa2.getWritableBytes() > 0) {
+    totalSent += packetSize;
+    copa2.onPacketSent(createPacket(packetNumToSend, packetSize, totalSent));
+  }
+
+  now += 10ms;
+  // Set the min rtt
+  conn.lossState.lrtt = 100ms;
+  copa2.onPacketAckOrLoss(createAckEvent(1, packetSize, now), folly::none);
+  EXPECT_FALSE(copa2.inProbeRtt());
+
+  now += kCopa2ProbeRttInterval / 2;
+  conn.lossState.lrtt = 250ms;
+  copa2.onPacketAckOrLoss(createAckEvent(1, packetSize, now), folly::none);
+  EXPECT_FALSE(copa2.inProbeRtt());
+
+  now += kCopa2ProbeRttInterval / 2;
+  copa2.onPacketAckOrLoss(createAckEvent(1, packetSize, now), folly::none);
+  EXPECT_TRUE(copa2.inProbeRtt());
+
+  conn.lossState.lrtt = 150ms;
+  now += kCopa2ProbeRttInterval / 2 - 50ms;
+  copa2.onPacketAckOrLoss(createAckEvent(1, packetSize, now), folly::none);
+  EXPECT_FALSE(copa2.inProbeRtt());
+
+  // If delay is small enough, it will enter probe rtt after half the usual
+  // period
+  conn.lossState.lrtt = 150ms;
+  now += 100ms;
+  copa2.onPacketAckOrLoss(createAckEvent(1, packetSize, now), folly::none);
+  EXPECT_TRUE(copa2.inProbeRtt());
+}
+
+TEST_F(Copa2Test, LossModeHappens) {
+  QuicServerConnectionState conn(
+      FizzServerQuicHandshakeContext::Builder().build());
+  // Tests assume lossToleranceParam = 0.05;
+  auto alphaParam = 10;
+  conn.transportSettings.initCwndInMss = 10;
+
+  Copa2 copa2(conn);
+  auto now = Clock::now();
+  auto packetSize = conn.udpSendPacketLen;
+  uint64_t totalSent = 0;
+  auto packetNumToSend = 1;
+  conn.lossState.lrtt = 10ms;
+  while (copa2.getWritableBytes() > 0) {
+    totalSent += packetSize;
+    copa2.onPacketSent(createPacket(packetNumToSend, packetSize, totalSent));
+    packetNumToSend += 1;
+  }
+
+  // You get ack for the first 8 packets all at once and then 1 loss
+  // followed by another loss. We should not shift to loss mode in the
+  // first one but we should in the second one.
+  CongestionController::LossEvent loss;
+  loss.largestLostPacketNum = 9;
+  loss.lostBytes = 1 * packetSize;
+  loss.persistentCongestion = false;
+  loss.lostPackets = 1;
+  loss.largestLostSentTime = now;
+  // Start the cycle
+  copa2.onPacketAckOrLoss(createAckEvent(1, packetSize, now), folly::none);
+  now += 21ms;
+  // End it
+  copa2.onPacketAckOrLoss(createAckEvent(8, 7 * packetSize, now), loss);
+  EXPECT_FALSE(copa2.inLossyMode());
+  EXPECT_EQ(
+      copa2.getCongestionWindow(), (8 + alphaParam) * conn.udpSendPacketLen);
+
+  // Should shift to loss mode now
+  loss.largestLostPacketNum = 10;
+  copa2.onPacketAckOrLoss(folly::none, loss);
+  EXPECT_TRUE(copa2.inLossyMode());
+
+  // Send the next cycle and ensure that we are sending fewer packets
+  // as appropriate in lossy mode
+  totalSent += packetSize;
+  copa2.onPacketSent(createPacket(packetNumToSend, packetSize, totalSent));
+
+  // Ack it at 10ms + 10ms * 2 * lossToleranceParam + 1ms
+  now += 12ms;
+  copa2.onPacketAckOrLoss(createAckEvent(1, packetSize, now), folly::none);
+  EXPECT_EQ(
+      copa2.getCongestionWindow(),
+      packetSize + alphaParam * conn.udpSendPacketLen);
+}
+
+} // namespace quic::test


### PR DESCRIPTION
Summary:
Reference algorithm: https://github.com/venkatarun95/cc_sim/blob/8089de1496d34d519f6d53efd2f0ec1b95d97003/src/copa2.rs

Algorithm Description:
Copa2 looks at the number of bytes acked in the last (RTT_min + D) seconds. Call it X

It sets the cwnd to X + alpha. Pacing is at cwnd / min_rtt

Here, alpha = 10 packets (any constant works)

Normally, D = min_rtt, unless there is excessive loss, in which case it is reduced

It periodically reduces cwnd to the min value to discover the min rtt

Differential Revision: D24950751

