### PR TITLE
GoogleTest v1.10 compatibility

### DIFF
--- a/build/fbcode_builder/manifests/mvfst
+++ b/build/fbcode_builder/manifests/mvfst
@@ -25,7 +25,7 @@ folly
 fizz
 
 [dependencies.all(test=on, not(os=windows))]
-googletest_1_8
+googletest
 
 [shipit.pathmap]
 fbcode/quic/public_root = .

--- a/build/fbcode_builder/specs/gmock.py
+++ b/build/fbcode_builder/specs/gmock.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 
 def fbcode_builder_spec(builder):
-    builder.add_option('google/googletest:git_hash', 'release-1.8.1')
+    builder.add_option('google/googletest:git_hash', 'release-1.10.0')
     builder.add_option(
         'google/googletest:cmake_defines',
         {

--- a/build_helper.sh
+++ b/build_helper.sh
@@ -211,7 +211,7 @@ function setup_googletest() {
   fi
   cd "$GTEST_DIR"
   git fetch --tags
-  git checkout release-1.8.0
+  git checkout release-1.10.0
   echo -e "${COLOR_GREEN}Building googletest ${COLOR_OFF}"
   mkdir -p "$GTEST_BUILD_DIR"
   cd "$GTEST_BUILD_DIR" || exit

--- a/cmake/QuicTest.cmake
+++ b/cmake/QuicTest.cmake
@@ -6,8 +6,8 @@
 include(CTest)
 
 if(BUILD_TESTS)
-  find_package(GMock 1.8.0 MODULE REQUIRED)
-  find_package(GTest 1.8.0 MODULE REQUIRED)
+  find_package(GMock 1.10.0 MODULE REQUIRED)
+  find_package(GTest 1.10.0 MODULE REQUIRED)
 endif()
 
 function(quic_add_test)

--- a/quic/api/test/MockQuicSocket.h
+++ b/quic/api/test/MockQuicSocket.h
@@ -145,10 +145,10 @@ class MockQuicSocket : public QuicSocket {
       folly::Expected<StreamId, LocalErrorCode>(bool));
   MOCK_CONST_METHOD0(getNumOpenableBidirectionalStreams, uint64_t());
   MOCK_CONST_METHOD0(getNumOpenableUnidirectionalStreams, uint64_t());
-  GMOCK_METHOD1_(, noexcept, , isClientStream, bool(StreamId));
-  GMOCK_METHOD1_(, noexcept, , isServerStream, bool(StreamId));
-  GMOCK_METHOD1_(, noexcept, , isBidirectionalStream, bool(StreamId));
-  GMOCK_METHOD1_(, noexcept, , isUnidirectionalStream, bool(StreamId));
+  MOCK_METHOD(bool, isClientStream, (StreamId), (noexcept));
+  MOCK_METHOD(bool, isServerStream, (StreamId), (noexcept));
+  MOCK_METHOD(bool, isBidirectionalStream, (StreamId), (noexcept));
+  MOCK_METHOD(bool, isUnidirectionalStream, (StreamId), (noexcept));
   MOCK_METHOD1(
       notifyPendingWriteOnConnection,
       folly::Expected<folly::Unit, LocalErrorCode>(WriteCallback*));

--- a/quic/api/test/Mocks.h
+++ b/quic/api/test/Mocks.h
@@ -43,7 +43,7 @@ class MockFrameScheduler : public FrameScheduler {
 class MockReadCallback : public QuicSocket::ReadCallback {
  public:
   ~MockReadCallback() override = default;
-  GMOCK_METHOD1_(, noexcept, , readAvailable, void(StreamId));
+  MOCK_METHOD(void, readAvailable, (StreamId), (noexcept));
   GMOCK_METHOD2_(
       ,
       noexcept,
@@ -70,7 +70,7 @@ class MockWriteCallback : public QuicSocket::WriteCallback {
   ~MockWriteCallback() override = default;
 
   GMOCK_METHOD2_(, noexcept, , onStreamWriteReady, void(StreamId, uint64_t));
-  GMOCK_METHOD1_(, noexcept, , onConnectionWriteReady, void(uint64_t));
+  MOCK_METHOD(void, onConnectionWriteReady, (uint64_t), (noexcept));
   GMOCK_METHOD2_(
       ,
       noexcept,
@@ -91,9 +91,9 @@ class MockConnectionCallback : public QuicSocket::ConnectionCallback {
  public:
   ~MockConnectionCallback() override = default;
 
-  GMOCK_METHOD1_(, noexcept, , onFlowControlUpdate, void(StreamId));
-  GMOCK_METHOD1_(, noexcept, , onNewBidirectionalStream, void(StreamId));
-  GMOCK_METHOD1_(, noexcept, , onNewUnidirectionalStream, void(StreamId));
+  MOCK_METHOD(void, onFlowControlUpdate, (StreamId), (noexcept));
+  MOCK_METHOD(void, onNewBidirectionalStream, (StreamId), (noexcept));
+  MOCK_METHOD(void, onNewUnidirectionalStream, (StreamId), (noexcept));
   GMOCK_METHOD2_(
       ,
       noexcept,
@@ -110,7 +110,7 @@ class MockConnectionCallback : public QuicSocket::ConnectionCallback {
   GMOCK_METHOD0_(, noexcept, , onReplaySafe, void());
   GMOCK_METHOD0_(, noexcept, , onTransportReady, void());
   GMOCK_METHOD0_(, noexcept, , onFirstPeerPacketProcessed, void());
-  GMOCK_METHOD1_(, noexcept, , onBidirectionalStreamsAvailable, void(uint64_t));
+  MOCK_METHOD(void, onBidirectionalStreamsAvailable, (uint64_t), (noexcept));
   GMOCK_METHOD1_(
       ,
       noexcept,
@@ -221,7 +221,7 @@ class MockQuicTransport : public QuicServerTransport {
 
   GMOCK_METHOD1_(, , , setTransportSettings, void(TransportSettings));
 
-  GMOCK_METHOD1_(, noexcept, , setPacingTimer, void(TimerHighRes::SharedPtr));
+  MOCK_METHOD(void, setPacingTimer, (TimerHighRes::SharedPtr), (noexcept));
 
   void onNetworkData(
       const folly::SocketAddress& peer,
@@ -293,7 +293,7 @@ class MockQuicTransport : public QuicServerTransport {
       setTransportStatsCallback,
       void(QuicTransportStatsCallback*));
 
-  GMOCK_METHOD1_(, noexcept, , setConnectionIdAlgo, void(ConnectionIdAlgo*));
+  MOCK_METHOD(void, setConnectionIdAlgo, (ConnectionIdAlgo*), (noexcept));
 
   MOCK_METHOD1(setBufAccessor, void(BufAccessor*));
 };
@@ -309,9 +309,9 @@ class MockLoopDetectorCallback : public LoopDetectorCallback {
 
 class MockLifecycleObserver : public LifecycleObserver {
  public:
-  GMOCK_METHOD1_(, noexcept, , observerAttach, void(QuicSocket*));
-  GMOCK_METHOD1_(, noexcept, , observerDetach, void(QuicSocket*));
-  GMOCK_METHOD1_(, noexcept, , destroy, void(QuicSocket*));
+  MOCK_METHOD(void, observerAttach, (QuicSocket*), (noexcept));
+  MOCK_METHOD(void, observerDetach, (QuicSocket*), (noexcept));
+  MOCK_METHOD(void, destroy, (QuicSocket*), (noexcept));
   GMOCK_METHOD2_(, noexcept, , evbAttach, void(QuicSocket*, folly::EventBase*));
   GMOCK_METHOD2_(, noexcept, , evbDetach, void(QuicSocket*, folly::EventBase*));
   GMOCK_METHOD2_(
@@ -326,8 +326,8 @@ class MockLifecycleObserver : public LifecycleObserver {
 
 class MockInstrumentationObserver : public InstrumentationObserver {
  public:
-  GMOCK_METHOD1_(, noexcept, , observerDetach, void(QuicSocket*));
-  GMOCK_METHOD1_(, noexcept, , appRateLimited, void(QuicSocket*));
+  MOCK_METHOD(void, observerDetach, (QuicSocket*), (noexcept));
+  MOCK_METHOD(void, appRateLimited, (QuicSocket*), (noexcept));
   GMOCK_METHOD2_(
       ,
       noexcept,
@@ -340,7 +340,7 @@ class MockInstrumentationObserver : public InstrumentationObserver {
       ,
       rttSampleGenerated,
       void(QuicSocket*, const PacketRTT&));
-  GMOCK_METHOD1_(, noexcept, , pmtuProbingStarted, void(QuicSocket*));
+  MOCK_METHOD(void, pmtuProbingStarted, (QuicSocket*), (noexcept));
   GMOCK_METHOD2_(
       ,
       noexcept,

--- a/quic/api/test/Mocks.h
+++ b/quic/api/test/Mocks.h
@@ -34,7 +34,7 @@ class MockFrameScheduler : public FrameScheduler {
     return _scheduleFramesForPacket(&builderIn, writableBytes);
   }
 
-  GMOCK_METHOD0_(, const, , hasData, bool());
+  MOCK_METHOD(bool, hasData, (), (const));
   MOCK_METHOD2(
       _scheduleFramesForPacket,
       SchedulingResult(PacketBuilderInterface*, uint32_t));
@@ -44,47 +44,28 @@ class MockReadCallback : public QuicSocket::ReadCallback {
  public:
   ~MockReadCallback() override = default;
   MOCK_METHOD(void, readAvailable, (StreamId), (noexcept));
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      readError,
-      void(
-          StreamId,
-          std::pair<QuicErrorCode, folly::Optional<folly::StringPiece>>));
+  MOCK_METHOD(void, readError, (StreamId,
+              (std::pair<QuicErrorCode, folly::Optional<folly::StringPiece>>)),
+              (noexcept));
 };
 
 class MockPeekCallback : public QuicSocket::PeekCallback {
  public:
   ~MockPeekCallback() override = default;
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      onDataAvailable,
-      void(StreamId, const folly::Range<PeekIterator>&));
+  MOCK_METHOD(void, onDataAvailable,
+              (StreamId, const folly::Range<PeekIterator>&), (noexcept));
 };
 
 class MockWriteCallback : public QuicSocket::WriteCallback {
  public:
   ~MockWriteCallback() override = default;
 
-  GMOCK_METHOD2_(, noexcept, , onStreamWriteReady, void(StreamId, uint64_t));
+  MOCK_METHOD(void, onStreamWriteReady, (StreamId, uint64_t), (noexcept));
   MOCK_METHOD(void, onConnectionWriteReady, (uint64_t), (noexcept));
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      onStreamWriteError,
-      void(
-          StreamId,
-          std::pair<QuicErrorCode, folly::Optional<folly::StringPiece>>));
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      onConnectionWriteError,
-      void(std::pair<QuicErrorCode, folly::Optional<folly::StringPiece>>));
+
+  using Error = std::pair<QuicErrorCode, folly::Optional<folly::StringPiece>>;
+  MOCK_METHOD(void, onStreamWriteError, (StreamId, Error), (noexcept));
+  MOCK_METHOD(void, onConnectionWriteError, (Error), (noexcept));
 };
 
 class MockConnectionCallback : public QuicSocket::ConnectionCallback {
@@ -94,38 +75,22 @@ class MockConnectionCallback : public QuicSocket::ConnectionCallback {
   MOCK_METHOD(void, onFlowControlUpdate, (StreamId), (noexcept));
   MOCK_METHOD(void, onNewBidirectionalStream, (StreamId), (noexcept));
   MOCK_METHOD(void, onNewUnidirectionalStream, (StreamId), (noexcept));
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      onStopSending,
-      void(StreamId, ApplicationErrorCode));
+  MOCK_METHOD(void, onStopSending, (StreamId, ApplicationErrorCode), (noexcept));
   MOCK_METHOD(void, onConnectionEnd, (), (noexcept));
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      onConnectionError,
-      void(std::pair<QuicErrorCode, std::string>));
+  MOCK_METHOD(void, onConnectionError, ((std::pair<QuicErrorCode, std::string>)), (noexcept));
   MOCK_METHOD(void, onReplaySafe, (), (noexcept));
   MOCK_METHOD(void, onTransportReady, (), (noexcept));
   MOCK_METHOD(void, onFirstPeerPacketProcessed, (), (noexcept));
   MOCK_METHOD(void, onBidirectionalStreamsAvailable, (uint64_t), (noexcept));
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      onUnidirectionalStreamsAvailable,
-      void(uint64_t));
+  MOCK_METHOD(void, onUnidirectionalStreamsAvailable, (uint64_t), (noexcept));
   MOCK_METHOD(void, onAppRateLimited, (), (noexcept));
 };
 
 class MockDeliveryCallback : public QuicSocket::DeliveryCallback {
  public:
   ~MockDeliveryCallback() override = default;
-  MOCK_METHOD3(
-      onDeliveryAck,
-      void(StreamId, uint64_t, std::chrono::microseconds));
+  MOCK_METHOD(void, onDeliveryAck,
+              (StreamId, uint64_t, std::chrono::microseconds), (noexcept));
   MOCK_METHOD2(onCanceled, void(StreamId, uint64_t));
 };
 
@@ -157,13 +122,13 @@ class MockByteEventCallback : public QuicSocket::ByteEventCallback {
 class MockDataExpiredCallback : public QuicSocket::DataExpiredCallback {
  public:
   ~MockDataExpiredCallback() override = default;
-  GMOCK_METHOD2_(, noexcept, , onDataExpired, void(StreamId, uint64_t));
+  MOCK_METHOD(void, onDataExpired, (StreamId, uint64_t), (noexcept));
 };
 
 class MockDataRejectedCallback : public QuicSocket::DataRejectedCallback {
  public:
   ~MockDataRejectedCallback() override = default;
-  GMOCK_METHOD2_(, noexcept, , onDataRejected, void(StreamId, uint64_t));
+  MOCK_METHOD(void, onDataRejected, (StreamId, uint64_t), (noexcept));
 };
 
 class MockQuicTransport : public QuicServerTransport {
@@ -204,22 +169,17 @@ class MockQuicTransport : public QuicServerTransport {
 
   MOCK_METHOD0(customDestructor, void());
 
-  GMOCK_METHOD0_(, const, , getEventBase, folly::EventBase*());
+  MOCK_METHOD(folly::EventBase*, getEventBase, (), (const));
 
   MOCK_CONST_METHOD0(getPeerAddress, const folly::SocketAddress&());
 
   MOCK_CONST_METHOD0(getOriginalPeerAddress, const folly::SocketAddress&());
 
-  GMOCK_METHOD1_(
-      ,
-      ,
-      ,
-      setOriginalPeerAddress,
-      void(const folly::SocketAddress&));
+  MOCK_METHOD(void, setOriginalPeerAddress, (const folly::SocketAddress&), ());
 
-  GMOCK_METHOD0_(, , , accept, void());
+  MOCK_METHOD(void, accept, (), ());
 
-  GMOCK_METHOD1_(, , , setTransportSettings, void(TransportSettings));
+  MOCK_METHOD(void, setTransportSettings, (TransportSettings), ());
 
   MOCK_METHOD(void, setPacingTimer, (TimerHighRes::SharedPtr), (noexcept));
 
@@ -229,69 +189,32 @@ class MockQuicTransport : public QuicServerTransport {
     onNetworkData(peer, networkData);
   }
 
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      onNetworkData,
-      void(const folly::SocketAddress&, const NetworkData&));
+  MOCK_METHOD(void, onNetworkData,
+              (const folly::SocketAddress&, const NetworkData&), (noexcept));
 
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      setRoutingCallback,
-      void(QuicServerTransport::RoutingCallback*));
+  MOCK_METHOD(void, setRoutingCallback,
+              (QuicServerTransport::RoutingCallback*), (noexcept));
 
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      setSupportedVersions,
-      void(const std::vector<QuicVersion>&));
+  MOCK_METHOD(void, setSupportedVersions,
+              (const std::vector<QuicVersion>&), (noexcept));
 
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      setServerConnectionIdParams,
-      void(ServerConnectionIdParams));
+  MOCK_METHOD(void, setServerConnectionIdParams, (ServerConnectionIdParams),
+              (noexcept));
 
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      close,
-      void(folly::Optional<std::pair<QuicErrorCode, std::string>>));
+  using Error = folly::Optional<std::pair<QuicErrorCode, std::string>>;
+  MOCK_METHOD(void, close, (Error), (noexcept));
+  MOCK_METHOD(void, closeNow, (Error), (noexcept));
 
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      closeNow,
-      void(folly::Optional<std::pair<QuicErrorCode, std::string>>));
+  MOCK_METHOD(bool, hasShutdown, (), (const));
 
-  GMOCK_METHOD0_(, const, , hasShutdown, bool());
+  MOCK_METHOD(folly::Optional<ConnectionId>, getClientConnectionId, (),
+              (const));
 
-  GMOCK_METHOD0_(
-      ,
-      const,
-      ,
-      getClientConnectionId,
-      folly::Optional<ConnectionId>());
-  GMOCK_METHOD0_(
-      ,
-      const,
-      ,
-      getClientChosenDestConnectionId,
-      folly::Optional<ConnectionId>());
+  MOCK_METHOD(folly::Optional<ConnectionId>, getClientChosenDestConnectionId,
+              (), (const));
 
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      setTransportStatsCallback,
-      void(QuicTransportStatsCallback*));
+  MOCK_METHOD(void, setTransportStatsCallback, (QuicTransportStatsCallback*),
+              (noexcept));
 
   MOCK_METHOD(void, setConnectionIdAlgo, (ConnectionIdAlgo*), (noexcept));
 
@@ -312,47 +235,26 @@ class MockLifecycleObserver : public LifecycleObserver {
   MOCK_METHOD(void, observerAttach, (QuicSocket*), (noexcept));
   MOCK_METHOD(void, observerDetach, (QuicSocket*), (noexcept));
   MOCK_METHOD(void, destroy, (QuicSocket*), (noexcept));
-  GMOCK_METHOD2_(, noexcept, , evbAttach, void(QuicSocket*, folly::EventBase*));
-  GMOCK_METHOD2_(, noexcept, , evbDetach, void(QuicSocket*, folly::EventBase*));
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      close,
-      void(
-          QuicSocket*,
-          const folly::Optional<std::pair<QuicErrorCode, std::string>>&));
+  MOCK_METHOD(void, evbAttach, (QuicSocket*, folly::EventBase*), (noexcept));
+  MOCK_METHOD(void, evbDetach, (QuicSocket*, folly::EventBase*), (noexcept));
+  MOCK_METHOD(void, close, (QuicSocket*,
+              (const folly::Optional<std::pair<QuicErrorCode, std::string>>&)),
+              (noexcept));
 };
 
 class MockInstrumentationObserver : public InstrumentationObserver {
  public:
   MOCK_METHOD(void, observerDetach, (QuicSocket*), (noexcept));
   MOCK_METHOD(void, appRateLimited, (QuicSocket*), (noexcept));
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      packetLossDetected,
-      void(QuicSocket*, const ObserverLossEvent&));
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      rttSampleGenerated,
-      void(QuicSocket*, const PacketRTT&));
+  MOCK_METHOD(void, packetLossDetected, (QuicSocket*, const ObserverLossEvent&),
+              (noexcept));
+  MOCK_METHOD(void, rttSampleGenerated, (QuicSocket*, const PacketRTT&),
+              (noexcept));
   MOCK_METHOD(void, pmtuProbingStarted, (QuicSocket*), (noexcept));
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      pmtuBlackholeDetected,
-      void(QuicSocket*, const PMTUBlackholeEvent&));
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      pmtuUpperBoundDetected,
-      void(QuicSocket*, const PMTUUpperBoundEvent&));
+  MOCK_METHOD(void, pmtuBlackholeDetected,
+              (QuicSocket*, const PMTUBlackholeEvent&), (noexcept));
+  MOCK_METHOD(void, pmtuUpperBoundDetected,
+              (QuicSocket*, const PMTUUpperBoundEvent&), (noexcept));
 
   static auto getLossPacketMatcher(bool reorderLoss, bool timeoutLoss) {
     return AllOf(

--- a/quic/api/test/Mocks.h
+++ b/quic/api/test/Mocks.h
@@ -100,16 +100,16 @@ class MockConnectionCallback : public QuicSocket::ConnectionCallback {
       ,
       onStopSending,
       void(StreamId, ApplicationErrorCode));
-  GMOCK_METHOD0_(, noexcept, , onConnectionEnd, void());
+  MOCK_METHOD(void, onConnectionEnd, (), (noexcept));
   GMOCK_METHOD1_(
       ,
       noexcept,
       ,
       onConnectionError,
       void(std::pair<QuicErrorCode, std::string>));
-  GMOCK_METHOD0_(, noexcept, , onReplaySafe, void());
-  GMOCK_METHOD0_(, noexcept, , onTransportReady, void());
-  GMOCK_METHOD0_(, noexcept, , onFirstPeerPacketProcessed, void());
+  MOCK_METHOD(void, onReplaySafe, (), (noexcept));
+  MOCK_METHOD(void, onTransportReady, (), (noexcept));
+  MOCK_METHOD(void, onFirstPeerPacketProcessed, (), (noexcept));
   MOCK_METHOD(void, onBidirectionalStreamsAvailable, (uint64_t), (noexcept));
   GMOCK_METHOD1_(
       ,
@@ -117,7 +117,7 @@ class MockConnectionCallback : public QuicSocket::ConnectionCallback {
       ,
       onUnidirectionalStreamsAvailable,
       void(uint64_t));
-  GMOCK_METHOD0_(, noexcept, , onAppRateLimited, void());
+  MOCK_METHOD(void, onAppRateLimited, (), (noexcept));
 };
 
 class MockDeliveryCallback : public QuicSocket::DeliveryCallback {

--- a/quic/codec/test/Mocks.h
+++ b/quic/codec/test/Mocks.h
@@ -18,7 +18,7 @@ namespace test {
 
 class MockConnectionIdAlgo : public ConnectionIdAlgo {
  public:
-  GMOCK_METHOD1_(, noexcept, , canParseNonConst, bool(const ConnectionId& id));
+  MOCK_METHOD(bool, canParseNonConst, (const ConnectionId& id), (noexcept));
   GMOCK_METHOD1_(
       ,
       noexcept,
@@ -66,7 +66,7 @@ class MockQuicPacketBuilder : public PacketBuilderInterface {
   MOCK_METHOD2(appendBytes, void(PacketNum, uint8_t));
   MOCK_METHOD3(appendBytesWithAppender, void(BufAppender&, PacketNum, uint8_t));
   MOCK_METHOD3(appendBytesWithBufWriter, void(BufWriter&, PacketNum, uint8_t));
-  GMOCK_METHOD1_(, noexcept, , accountForCipherOverhead, void(uint8_t));
+  MOCK_METHOD(void, accountForCipherOverhead, (uint8_t), (noexcept));
   GMOCK_METHOD0_(, noexcept, , canBuildPacketNonConst, bool());
   GMOCK_METHOD0_(, const, , getHeaderBytes, uint32_t());
   GMOCK_METHOD0_(, const, , hasFramesPending, bool());

--- a/quic/codec/test/Mocks.h
+++ b/quic/codec/test/Mocks.h
@@ -67,7 +67,7 @@ class MockQuicPacketBuilder : public PacketBuilderInterface {
   MOCK_METHOD3(appendBytesWithAppender, void(BufAppender&, PacketNum, uint8_t));
   MOCK_METHOD3(appendBytesWithBufWriter, void(BufWriter&, PacketNum, uint8_t));
   MOCK_METHOD(void, accountForCipherOverhead, (uint8_t), (noexcept));
-  GMOCK_METHOD0_(, noexcept, , canBuildPacketNonConst, bool());
+  MOCK_METHOD(bool, canBuildPacketNonConst, (), (noexcept));
   GMOCK_METHOD0_(, const, , getHeaderBytes, uint32_t());
   GMOCK_METHOD0_(, const, , hasFramesPending, bool());
   MOCK_METHOD0(releaseOutputBufferMock, void());

--- a/quic/codec/test/Mocks.h
+++ b/quic/codec/test/Mocks.h
@@ -19,20 +19,12 @@ namespace test {
 class MockConnectionIdAlgo : public ConnectionIdAlgo {
  public:
   MOCK_METHOD(bool, canParseNonConst, (const ConnectionId& id), (noexcept));
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      parseConnectionId,
-      folly::Expected<ServerConnectionIdParams, QuicInternalException>(
-          const ConnectionId&));
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      encodeConnectionId,
-      folly::Expected<ConnectionId, QuicInternalException>(
-          const ServerConnectionIdParams&));
+  MOCK_METHOD(
+      (folly::Expected<ServerConnectionIdParams, QuicInternalException>),
+      parseConnectionId, (const ConnectionId&), (noexcept));
+  MOCK_METHOD((folly::Expected<ConnectionId, QuicInternalException>),
+              encodeConnectionId, (const ServerConnectionIdParams&),
+              (noexcept));
 
   bool canParse(const ConnectionId& id) const noexcept override {
     return const_cast<MockConnectionIdAlgo&>(*this).canParseNonConst(id);
@@ -56,8 +48,8 @@ class MockQuicPacketBuilder : public PacketBuilderInterface {
   MOCK_METHOD2(push, void(const uint8_t*, size_t));
   MOCK_METHOD1(write, void(const QuicInteger&));
 
-  GMOCK_METHOD0_(, const, , remainingSpaceInPkt, uint32_t());
-  GMOCK_METHOD0_(, const, , getPacketHeader, const PacketHeader&());
+  MOCK_METHOD(uint32_t, remainingSpaceInPkt, (), (const));
+  MOCK_METHOD(const PacketHeader&, getPacketHeader, (), (const));
 
   MOCK_METHOD1(writeBEUint8, void(uint8_t));
   MOCK_METHOD1(writeBEUint16, void(uint16_t));
@@ -68,8 +60,8 @@ class MockQuicPacketBuilder : public PacketBuilderInterface {
   MOCK_METHOD3(appendBytesWithBufWriter, void(BufWriter&, PacketNum, uint8_t));
   MOCK_METHOD(void, accountForCipherOverhead, (uint8_t), (noexcept));
   MOCK_METHOD(bool, canBuildPacketNonConst, (), (noexcept));
-  GMOCK_METHOD0_(, const, , getHeaderBytes, uint32_t());
-  GMOCK_METHOD0_(, const, , hasFramesPending, bool());
+  MOCK_METHOD(uint32_t, getHeaderBytes, (), (const));
+  MOCK_METHOD(bool, hasFramesPending, (), (const));
   MOCK_METHOD0(releaseOutputBufferMock, void());
   MOCK_METHOD0(encodePacketHeader, void());
 

--- a/quic/congestion_control/test/Mocks.h
+++ b/quic/congestion_control/test/Mocks.h
@@ -26,7 +26,7 @@ class MockMinRttSampler : public BbrCongestionController::MinRttSampler {
       ,
       newRttSample,
       bool(std::chrono::microseconds, TimePoint));
-  GMOCK_METHOD1_(, noexcept, , timestampMinRtt, void(TimePoint));
+  MOCK_METHOD(void, timestampMinRtt, (TimePoint), (noexcept));
 };
 
 class MockBandwidthSampler : public BbrCongestionController::BandwidthSampler {

--- a/quic/congestion_control/test/Mocks.h
+++ b/quic/congestion_control/test/Mocks.h
@@ -20,12 +20,8 @@ class MockMinRttSampler : public BbrCongestionController::MinRttSampler {
 
   MOCK_CONST_METHOD0(minRtt, std::chrono::microseconds());
   MOCK_CONST_METHOD0(minRttExpired, bool());
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      newRttSample,
-      bool(std::chrono::microseconds, TimePoint));
+  MOCK_METHOD(bool, newRttSample, (std::chrono::microseconds, TimePoint),
+              (noexcept));
   MOCK_METHOD(void, timestampMinRtt, (TimePoint), (noexcept));
 };
 

--- a/quic/fizz/client/test/QuicClientTransportTest.cpp
+++ b/quic/fizz/client/test/QuicClientTransportTest.cpp
@@ -1904,21 +1904,13 @@ TEST_F(QuicClientTransportTest, SocketClosedDuringOnTransportReady) {
     MOCK_METHOD(void, onFlowControlUpdate, (StreamId), (noexcept));
     MOCK_METHOD(void, onNewBidirectionalStream, (StreamId), (noexcept));
     MOCK_METHOD(void, onNewUnidirectionalStream, (StreamId), (noexcept));
-    GMOCK_METHOD2_(
-        ,
-        noexcept,
-        ,
-        onStopSending,
-        void(StreamId, ApplicationErrorCode));
+    MOCK_METHOD(void, onStopSending, (StreamId, ApplicationErrorCode),
+                (noexcept));
     MOCK_METHOD(void, onTransportReadyMock, (), (noexcept));
     MOCK_METHOD(void, onReplaySafe, (), (noexcept));
     MOCK_METHOD(void, onConnectionEnd, (), (noexcept));
-    GMOCK_METHOD1_(
-        ,
-        noexcept,
-        ,
-        onConnectionError,
-        void(std::pair<QuicErrorCode, std::string>));
+    MOCK_METHOD(void, onConnectionError,
+                ((std::pair<QuicErrorCode, std::string>)), (noexcept));
 
    private:
     std::shared_ptr<QuicSocket> socket_;

--- a/quic/fizz/client/test/QuicClientTransportTest.cpp
+++ b/quic/fizz/client/test/QuicClientTransportTest.cpp
@@ -1910,9 +1910,9 @@ TEST_F(QuicClientTransportTest, SocketClosedDuringOnTransportReady) {
         ,
         onStopSending,
         void(StreamId, ApplicationErrorCode));
-    GMOCK_METHOD0_(, noexcept, , onTransportReadyMock, void());
-    GMOCK_METHOD0_(, noexcept, , onReplaySafe, void());
-    GMOCK_METHOD0_(, noexcept, , onConnectionEnd, void());
+    MOCK_METHOD(void, onTransportReadyMock, (), (noexcept));
+    MOCK_METHOD(void, onReplaySafe, (), (noexcept));
+    MOCK_METHOD(void, onConnectionEnd, (), (noexcept));
     GMOCK_METHOD1_(
         ,
         noexcept,

--- a/quic/fizz/client/test/QuicClientTransportTest.cpp
+++ b/quic/fizz/client/test/QuicClientTransportTest.cpp
@@ -1901,9 +1901,9 @@ TEST_F(QuicClientTransportTest, SocketClosedDuringOnTransportReady) {
       onTransportReadyMock();
     }
 
-    GMOCK_METHOD1_(, noexcept, , onFlowControlUpdate, void(StreamId));
-    GMOCK_METHOD1_(, noexcept, , onNewBidirectionalStream, void(StreamId));
-    GMOCK_METHOD1_(, noexcept, , onNewUnidirectionalStream, void(StreamId));
+    MOCK_METHOD(void, onFlowControlUpdate, (StreamId), (noexcept));
+    MOCK_METHOD(void, onNewBidirectionalStream, (StreamId), (noexcept));
+    MOCK_METHOD(void, onNewUnidirectionalStream, (StreamId), (noexcept));
     GMOCK_METHOD2_(
         ,
         noexcept,

--- a/quic/server/handshake/test/ServerHandshakeTest.cpp
+++ b/quic/server/handshake/test/ServerHandshakeTest.cpp
@@ -48,7 +48,7 @@ class MockServerHandshakeCallback : public ServerHandshake::HandshakeCallback {
  public:
   ~MockServerHandshakeCallback() override = default;
 
-  GMOCK_METHOD0_(, noexcept, , onCryptoEventAvailable, void());
+  MOCK_METHOD(void, onCryptoEventAvailable, (), (noexcept));
 };
 
 struct TestingServerConnectionState : public QuicServerConnectionState {

--- a/quic/server/test/Mocks.h
+++ b/quic/server/test/Mocks.h
@@ -19,12 +19,8 @@ namespace quic {
 
 class MockServerConnectionIdRejector : public ServerConnectionIdRejector {
  public:
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      rejectConnectionIdNonConst,
-      bool(const ConnectionId));
+  MOCK_METHOD(bool, rejectConnectionIdNonConst,
+              (const ConnectionId), (noexcept));
 
   bool rejectConnectionId(const ConnectionId& id) const noexcept override {
     return const_cast<MockServerConnectionIdRejector&>(*this)
@@ -46,16 +42,11 @@ class MockQuicServerTransportFactory : public QuicServerTransportFactory {
     return _make(evb, socket, addr, ctx);
   }
 
-  GMOCK_METHOD4_(
-      ,
-      noexcept,
-      ,
-      _make,
-      QuicServerTransport::Ptr(
-          folly::EventBase* evb,
-          std::unique_ptr<folly::AsyncUDPSocket>& sock,
-          const folly::SocketAddress&,
-          std::shared_ptr<const fizz::server::FizzServerContext>));
+  MOCK_METHOD(QuicServerTransport::Ptr, _make, (folly::EventBase* evb,
+              std::unique_ptr<folly::AsyncUDPSocket>& sock,
+              const folly::SocketAddress&,
+              std::shared_ptr<const fizz::server::FizzServerContext>),
+              (noexcept));
 };
 
 class MockWorkerCallback : public QuicServerWorker::WorkerCallback {
@@ -107,26 +98,12 @@ class MockRoutingCallback : public QuicServerTransport::RoutingCallback {
  public:
   ~MockRoutingCallback() override = default;
 
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      onConnectionIdAvailable,
-      void(QuicServerTransport::Ptr, ConnectionId));
-  GMOCK_METHOD1_(
-      ,
-      noexcept,
-      ,
-      onConnectionIdBound,
-      void(QuicServerTransport::Ptr));
-  GMOCK_METHOD3_(
-      ,
-      noexcept,
-      ,
-      onConnectionUnbound,
-      void(
-          QuicServerTransport*,
-          const QuicServerTransport::SourceIdentity&,
-          const std::vector<ConnectionIdData>& connIdData));
+  MOCK_METHOD(void, onConnectionIdAvailable,
+              (QuicServerTransport::Ptr, ConnectionId), (noexcept));
+  MOCK_METHOD(void, onConnectionIdBound, (QuicServerTransport::Ptr),
+              (noexcept));
+  MOCK_METHOD(void, onConnectionUnbound, (QuicServerTransport*,
+              const QuicServerTransport::SourceIdentity&,
+              const std::vector<ConnectionIdData>& connIdData), (noexcept));
 };
 } // namespace quic

--- a/quic/server/test/QuicServerTest.cpp
+++ b/quic/server/test/QuicServerTest.cpp
@@ -1117,10 +1117,10 @@ TEST_F(QuicServerWorkerTest, AssignBufAccessor) {
 
 class MockAcceptObserver : public AcceptObserver {
  public:
-  GMOCK_METHOD1_(, noexcept, , accept, void(QuicTransportBase* const));
-  GMOCK_METHOD1_(, noexcept, , acceptorDestroy, void(QuicServerWorker*));
-  GMOCK_METHOD1_(, noexcept, , observerAttach, void(QuicServerWorker*));
-  GMOCK_METHOD1_(, noexcept, , observerDetach, void(QuicServerWorker*));
+  MOCK_METHOD(void, accept, (QuicTransportBase* const), (noexcept));
+  MOCK_METHOD(void, acceptorDestroy, (QuicServerWorker*), (noexcept));
+  MOCK_METHOD(void, observerAttach, (QuicServerWorker*), (noexcept));
+  MOCK_METHOD(void, observerDetach, (QuicServerWorker*), (noexcept));
 };
 
 TEST_F(QuicServerWorkerTest, AcceptObserver) {

--- a/quic/server/test/QuicServerTransportTest.cpp
+++ b/quic/server/test/QuicServerTransportTest.cpp
@@ -113,7 +113,7 @@ class FakeServerHandshake : public FizzServerHandshake {
     }
   }
 
-  Optional<ClientTransportParameters> getClientTransportParams() override {
+  folly::Optional<ClientTransportParameters> getClientTransportParams() override {
     std::vector<TransportParameter> transportParams;
     transportParams.push_back(encodeIntegerParameter(
         TransportParameterId::initial_max_stream_data_bidi_local,

--- a/quic/state/test/Mocks.h
+++ b/quic/state/test/Mocks.h
@@ -26,7 +26,7 @@ class MockCongestionController : public CongestionController {
   MOCK_CONST_METHOD0(getCongestionWindow, uint64_t());
   MOCK_METHOD0(onSpuriousLoss, void());
   MOCK_CONST_METHOD0(type, CongestionControlType());
-  GMOCK_METHOD2_(, , , setAppIdle, void(bool, TimePoint));
+  MOCK_METHOD(void, setAppIdle, (bool, TimePoint), ());
   MOCK_METHOD0(setAppLimited, void());
   MOCK_CONST_METHOD0(isAppLimited, bool());
   MOCK_CONST_METHOD1(getStats, void(CongestionControllerStats&));
@@ -52,12 +52,8 @@ class MockPendingPathRateLimiter : public PendingPathRateLimiter {
  public:
   MockPendingPathRateLimiter() : PendingPathRateLimiter(0) {}
   MOCK_METHOD1(onPacketSent, void(uint64_t));
-  GMOCK_METHOD2_(
-      ,
-      noexcept,
-      ,
-      currentCredit,
-      uint64_t(TimePoint, std::chrono::microseconds));
+  MOCK_METHOD(uint64_t, currentCredit,
+              (TimePoint, std::chrono::microseconds), (noexcept));
 };
 } // namespace test
 } // namespace quic


### PR DESCRIPTION
This PR replaces all internal `GMOCK_METHOD*_()` macro usage with the well-documented `MOCK_METHOD()`.
That way, mvfst tests can be compiled with GoogleTest v1.10.

`MOCK_METHOD()` requires `GoogleTest >= 1.10.0`, so the change is probably not as easy as I wanted it to be.

I'd be happy to contribute to the rest of Facebook's trinity as well (folly, fizz, wangle), if I could help with the transition.

See also: facebook/proxygen#347