### PR TITLE
Don't force STATIC for libraries

### DIFF
--- a/quic/api/CMakeLists.txt
+++ b/quic/api/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_batch_writer STATIC
+  mvfst_batch_writer
   QuicBatchWriter.cpp
   QuicBatchWriterFactory.cpp
   QuicBatchWriterFactoryMobile.cpp
@@ -41,7 +41,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_transport STATIC
+  mvfst_transport
   IoBufQuicBatch.cpp
   QuicPacketScheduler.cpp
   QuicStreamAsyncTransport.cpp

--- a/quic/client/CMakeLists.txt
+++ b/quic/client/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_client STATIC
+  mvfst_client
   QuicClientTransport.cpp
   QuicClientAsyncTransport.cpp
   handshake/ClientHandshake.cpp

--- a/quic/codec/CMakeLists.txt
+++ b/quic/codec/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_codec_types STATIC
+  mvfst_codec_types
   DefaultConnectionIdAlgo.cpp
   PacketNumber.cpp
   QuicConnectionId.cpp
@@ -41,7 +41,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_codec_decode STATIC
+  mvfst_codec_decode
   Decode.cpp
 )
 
@@ -71,7 +71,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_codec_packet_number_cipher STATIC
+  mvfst_codec_packet_number_cipher
   PacketNumberCipher.cpp
 )
 
@@ -101,7 +101,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_codec_pktbuilder STATIC
+  mvfst_codec_pktbuilder
   QuicPacketBuilder.cpp
 )
 
@@ -131,7 +131,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_codec_pktrebuilder STATIC
+  mvfst_codec_pktrebuilder
   QuicPacketRebuilder.cpp
 )
 
@@ -169,7 +169,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_codec STATIC
+  mvfst_codec
   QuicHeaderCodec.cpp
   QuicReadCodec.cpp
   QuicWriteCodec.cpp

--- a/quic/common/CMakeLists.txt
+++ b/quic/common/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_buf_accessor STATIC
+  mvfst_buf_accessor
   BufAccessor.cpp
 )
 
@@ -26,7 +26,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_looper STATIC
+  mvfst_looper
   FunctionLooper.cpp
   Timers.cpp
 )
@@ -49,7 +49,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_bufutil STATIC
+  mvfst_bufutil
   BufUtil.cpp
 )
 
@@ -71,7 +71,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_events STATIC
+  mvfst_events
   QuicEventBase.cpp
 )
 
@@ -93,7 +93,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_socketutil STATIC
+  mvfst_socketutil
   SocketUtil.cpp
 )
 
@@ -115,7 +115,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_transport_knobs STATIC
+  mvfst_transport_knobs
   TransportKnobs.cpp
 )
 
@@ -137,7 +137,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_async_udp_socket_wrapper STATIC
+  mvfst_async_udp_socket_wrapper
   QuicAsyncUDPSocketWrapper.cpp
 )
 

--- a/quic/common/test/CMakeLists.txt
+++ b/quic/common/test/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT BUILD_TESTS)
 endif()
 
 add_library(
-  mvfst_test_utils STATIC
+  mvfst_test_utils
   TestPacketBuilders.cpp
   TestUtils.cpp
   AeadTestUtil.cpp

--- a/quic/congestion_control/CMakeLists.txt
+++ b/quic/congestion_control/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_cc_algo STATIC
+  mvfst_cc_algo
   Bandwidth.cpp
   Bbr.cpp
   BbrBandwidthSampler.cpp

--- a/quic/fizz/client/CMakeLists.txt
+++ b/quic/fizz/client/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_fizz_client STATIC
+  mvfst_fizz_client
   handshake/FizzClientQuicHandshakeContext.cpp
   handshake/FizzClientHandshake.cpp
 )

--- a/quic/fizz/handshake/CMakeLists.txt
+++ b/quic/fizz/handshake/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_fizz_handshake STATIC
+  mvfst_fizz_handshake
   FizzBridge.cpp
   FizzCryptoFactory.cpp
   FizzPacketNumberCipher.cpp

--- a/quic/flowcontrol/CMakeLists.txt
+++ b/quic/flowcontrol/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_flowcontrol STATIC
+  mvfst_flowcontrol
   QuicFlowController.cpp
 )
 

--- a/quic/handshake/CMakeLists.txt
+++ b/quic/handshake/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_handshake STATIC
+  mvfst_handshake
   CryptoFactory.cpp
   HandshakeLayer.cpp
   TransportParameters.cpp

--- a/quic/happyeyeballs/CMakeLists.txt
+++ b/quic/happyeyeballs/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_happyeyeballs STATIC
+  mvfst_happyeyeballs
   QuicHappyEyeballsFunctions.cpp
 )
 

--- a/quic/logging/CMakeLists.txt
+++ b/quic/logging/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_qlogger STATIC
+  mvfst_qlogger
   BaseQLogger.cpp
   FileQLogger.cpp
   QLogger.cpp

--- a/quic/loss/CMakeLists.txt
+++ b/quic/loss/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_loss STATIC
+  mvfst_loss
   QuicLossFunctions.cpp
 )
 

--- a/quic/observer/CMakeLists.txt
+++ b/quic/observer/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_observer STATIC
+  mvfst_observer
   SocketObserverInterface.cpp
 )
 

--- a/quic/server/CMakeLists.txt
+++ b/quic/server/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(
-  mvfst_server_state STATIC
+  mvfst_server_state
   handshake/AppToken.cpp
   handshake/ServerHandshake.cpp
   handshake/StatelessResetGenerator.cpp
@@ -39,7 +39,7 @@ add_dependencies(
 
 
 add_library(
-  mvfst_server STATIC
+  mvfst_server
   QuicServer.cpp
   QuicServerBackend.cpp
   QuicServerPacketRouter.cpp
@@ -87,7 +87,7 @@ add_dependencies(
 )
 
 add_library(
-  mvfst_server_async_tran STATIC
+  mvfst_server_async_tran
   async_tran/QuicAsyncTransportAcceptor.cpp
   async_tran/QuicAsyncTransportServer.cpp
   async_tran/QuicServerAsyncTransport.cpp

--- a/quic/state/CMakeLists.txt
+++ b/quic/state/CMakeLists.txt
@@ -254,7 +254,7 @@ target_link_libraries(
 )
 
 add_library(
-  mvfst_state_stream STATIC
+  mvfst_state_stream
   stream/StreamStateFunctions.cpp
   stream/StreamSendHandlers.cpp
   stream/StreamReceiveHandlers.cpp
@@ -293,7 +293,7 @@ target_link_libraries(
 
 # transport settings functions
 add_library(
-  mvfst_transport_settings_functions STATIC
+  mvfst_transport_settings_functions
   TransportSettingsFunctions.cpp
 )
 


### PR DESCRIPTION
Summary:
- fbthrift recently picked up a dependency on mvfst/quic (D45366398)
- [hsthrift](https://github.com/facebookincubator/hsthrift) depends on fbthrift, and builds all its dependencies as shared libraries because
that's what Haskell needs
- mvfst forces `STATIC` for its libraries, which [breaks the `hsthrift` build](https://github.com/facebookincubator/hsthrift/actions/runs/5574612193/jobs/10183438709)

```
/usr/bin/ld: quic/codec/libmvfst_codec_types.a(QuicConnectionId.cpp.o): relocation R_X86_64_PC32 against symbol `_ZZN5folly7hexlifyINS_5RangeIPKhEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKT_RT0_bE9hexValues' can not be used when making a shared object; recompile with -fPIC
```

Forcing `STATIC` should be unnecessary, because `BUILD_SHARED_LIBS`
defaults to `NO`, I believe.

Differential Revision: D47511897

