### PR TITLE
fmt9+ compatibility

### DIFF
--- a/quic/server/QuicServerWorker.cpp
+++ b/quic/server/QuicServerWorker.cpp
@@ -696,9 +696,9 @@ PacketDropReason QuicServerWorker::isDstConnIdMisrouted(
     const auto& ex = maybeParsedConnIdParam.error();
     VLOG(3) << fmt::format(
         "Dropping packet due to DCID parsing error={}, errorCode={},"
-        "routingInfo = {} ",
+        "routingInfo={} ",
         ex.what(),
-        ex.errorCode(),
+        toString(ex.errorCode()),
         logRoutingInfo(dstConnId));
     // TODO do we need to reset?
     return PacketDropReason::PARSE_ERROR_DCID;


### PR DESCRIPTION
Summary:

Pass quic::LocalErrorCode to toString to return folly::StringPiece

```
/usr/include/fmt/core.h:2817:44:   required from ‘std::string fmt::v10::format(format_string<T ...>, T&& ...) [with T = {const char*, quic::LocalErrorCode, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}; std::string = std::__cxx11::basic_string<char>; format_string<T ...> = basic_format_string<char, const char*, quic::LocalErrorCode, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >]’
/tmp/mvfst/quic/server/QuicServerWorker.cpp:697:27:   required from here
/usr/include/fmt/core.h:1691:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1691 |       formattable,
      |       ^~~~~~~~~~~
```