### PR TITLE
Fix build failure with fmt 10

### DIFF
--- a/quic/server/QuicServerWorker.cpp
+++ b/quic/server/QuicServerWorker.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <folly/Conv.h>
+#include <folly/Utility.h>
 #include <quic/congestion_control/Bbr.h>
 #include <quic/congestion_control/Copa.h>
 #include <quic/fizz/handshake/FizzRetryIntegrityTagGenerator.h>
@@ -698,7 +699,7 @@ PacketDropReason QuicServerWorker::isDstConnIdMisrouted(
         "Dropping packet due to DCID parsing error={}, errorCode={},"
         "routingInfo = {} ",
         ex.what(),
-        ex.errorCode(),
+        folly::to_underlying(ex.errorCode()),
         logRoutingInfo(dstConnId));
     // TODO do we need to reset?
     return PacketDropReason::PARSE_ERROR_DCID;


### PR DESCRIPTION
This change is patterned after facebook/folly#2022.

An alternative fix would be to provide a formatter specialisation[^1] for `quic::LocalErrorCode`, but that's a bit more involved.

[^1]: See https://fmt.dev/10.0.0/api.html#udt.