### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/build/fbcode_builder/CMake/FBPythonBinary.cmake
+++ b/build/fbcode_builder/CMake/FBPythonBinary.cmake
@@ -32,7 +32,7 @@ if(NOT TARGET Python3::Interpreter)
   # We find with QUIET here, since otherwise this generates some noisy warnings
   # on versions of CMake before 3.12
   if (WIN32)
-    # On Windows we need both the Intepreter as well as the Development
+    # On Windows we need both the Interpreter as well as the Development
     # libraries.
     find_package(Python3 COMPONENTS Interpreter Development QUIET)
   else()
@@ -487,7 +487,7 @@ function(add_fb_python_library LIB_NAME)
     #   won't complain if one of the dependencies doesn't exist (since it is
     #   intended to allow passing in file names for plain library files rather
     #   than just targets).
-    # - It ensures that sources for our depencencies are built before any
+    # - It ensures that sources for our dependencies are built before any
     #   executable that depends on us.  Note that we depend on "${dep}.py_lib"
     #   rather than "${dep}.py_sources_built" for this purpose because the
     #   ".py_sources_built" target won't be available for imported targets.

--- a/build/fbcode_builder/CMake/fb_py_test_main.py
+++ b/build/fbcode_builder/CMake/fb_py_test_main.py
@@ -262,7 +262,7 @@ class BuckTestResult(unittest._TextTestResult):
 
         super(BuckTestResult, self).stopTest(test)
 
-        # If a failure occured during module/class setup, then this "test" may
+        # If a failure occurred during module/class setup, then this "test" may
         # actually be a `_ErrorHolder`, which doesn't contain explicit info
         # about the upcoming test.  Since we really only care about the test
         # name field (i.e. `_testMethodName`), we use that to detect an actual

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -626,7 +626,7 @@ class BuildCmd(ProjectCmdBase):
                     )
                     builder.build(install_dirs, reconfigure=reconfigure)
 
-                    # If we are building the project (not depdendency) and a specific
+                    # If we are building the project (not dependency) and a specific
                     # cmake_target (not 'install') has been requested, then we don't
                     # set the built_marker. This allows subsequent runs of getdeps.py
                     # for the project to run with different cmake_targets to trigger

--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -346,7 +346,7 @@ class AutoconfBuilder(BuilderBase):
 
 class Iproute2Builder(BuilderBase):
     # ./configure --prefix does not work for iproute2.
-    # Thus, explicitly copy sources from src_dir to build_dir, bulid,
+    # Thus, explicitly copy sources from src_dir to build_dir, build,
     # and then install to inst_dir using DESTDIR
     # lastly, also copy include from build_dir to inst_dir
     def __init__(self, build_opts, ctx, manifest, src_dir, build_dir, inst_dir) -> None:

--- a/build/fbcode_builder/getdeps/cargo.py
+++ b/build/fbcode_builder/getdeps/cargo.py
@@ -194,7 +194,7 @@ directory = "{vendored_dir}"
             my-rename-of-crate = { package = "crate", git = "..." }
 
         they can count themselves lucky because the code will raise an
-        Exception. There migh be more cases where the code will silently pass
+        Exception. There might be more cases where the code will silently pass
         producing bad results.
         """
         workspace_dir = self.workspace_dir()
@@ -362,7 +362,7 @@ path = "{null_file}"
 
         dep_to_crates = {}
 
-        # First populate explicit crate paths from depedencies
+        # First populate explicit crate paths from dependencies
         for name, git_conf in dep_to_git.items():
             crates = git_conf["crate_source_map"].keys()
             if crates:

--- a/build/fbcode_builder/getdeps/envfuncs.py
+++ b/build/fbcode_builder/getdeps/envfuncs.py
@@ -32,7 +32,7 @@ class Env(object):
         # project uses `unicode_literals`.  `subprocess` will raise an error
         # if the environment that it is passed has a mixture of byte and
         # unicode strings.
-        # It is simplest to force everthing to be `str` for the sake of
+        # It is simplest to force everything to be `str` for the sake of
         # consistency.
         key = str(key)
         if sys.platform.startswith("win"):

--- a/quic/QuicConstants.h
+++ b/quic/QuicConstants.h
@@ -359,7 +359,7 @@ constexpr std::chrono::microseconds kDefaultThreadLocalDelay = 1ms;
 constexpr int kRttAlpha = 8;
 constexpr int kRttBeta = 4;
 
-// Draft-17 recommends 100ms as initial RTT. We delibrately ignore that
+// Draft-17 recommends 100ms as initial RTT. We deliberately ignore that
 // recommendation. This is not a bug.
 constexpr std::chrono::microseconds kDefaultInitialRtt = 50000us;
 

--- a/quic/api/IoBufQuicBatch.cpp
+++ b/quic/api/IoBufQuicBatch.cpp
@@ -92,7 +92,7 @@ bool IOBufQuicBatch::flushInternal() {
     }
   }
 
-  // If error occured on first socket, kick off second socket immediately
+  // If error occurred on first socket, kick off second socket immediately
   if (!written && happyEyeballsState_ &&
       happyEyeballsState_->connAttemptDelayTimeout &&
       happyEyeballsState_->connAttemptDelayTimeout->isScheduled()) {

--- a/quic/api/QuicPacketScheduler.cpp
+++ b/quic/api/QuicPacketScheduler.cpp
@@ -580,7 +580,7 @@ folly::Optional<PacketNum> AckScheduler::writeNextAcks(
   auto ackingTime = Clock::now();
   DCHECK(ackState_.largestRecvdPacketTime.hasValue())
       << "Missing received time for the largest acked packet";
-  // assuming that we're going to ack the largest received with hightest pri
+  // assuming that we're going to ack the largest received with highest pri
   auto receivedTime = *ackState_.largestRecvdPacketTime;
   std::chrono::microseconds ackDelay =
       (ackingTime > receivedTime
@@ -771,7 +771,7 @@ void BlockedScheduler::writeBlockedFrames(PacketBuilderInterface& builder) {
     auto result = writeFrame(blockedFrame, builder);
     if (!result) {
       // If there is not enough room to write data blocked frame in the
-      // curretn packet, we won't be able to write stream blocked frames either
+      // current packet, we won't be able to write stream blocked frames either
       // so just return.
       return;
     }

--- a/quic/api/QuicPacketScheduler.h
+++ b/quic/api/QuicPacketScheduler.h
@@ -338,7 +338,7 @@ class FrameScheduler : public QuicPacketScheduler {
  * exiting packets that are still outstanding. A CloningScheduler first tries to
  * write new frames with new data into a packet. If that fails due to the lack
  * of new data, it falls back to cloning one inflight packet from a connection's
- * oustanding packets if there is at least one outstanding packet that's smaller
+ * outstanding packets if there is at least one outstanding packet that's smaller
  * than the writableBytes limit.
  */
 class CloningScheduler : public QuicPacketScheduler {

--- a/quic/api/QuicSocket.h
+++ b/quic/api/QuicSocket.h
@@ -57,7 +57,7 @@ class QuicSocket {
 
     /**
      * Called when the transport is ready to send/receive data.
-     * This can be potentially triggerred immidiately when using 0-RTT.
+     * This can be potentially triggered immediately when using 0-RTT.
      */
     virtual void onTransportReady() noexcept {}
 
@@ -698,7 +698,7 @@ class QuicSocket {
    * will return all available bytes.
    *
    * The return value is Expected.  If the value hasError(), then a read error
-   * occured and it can be obtained with error().  If the value hasValue(), then
+   * occurred and it can be obtained with error().  If the value hasValue(), then
    * value() returns a pair of the data (if any) and the EOF marker.
    *
    * Calling read() when there is no data/eof to deliver will return an
@@ -769,7 +769,7 @@ class QuicSocket {
    * Peek at the given stream.
    *
    * The return value is Expected.  If the value hasError(), then a read error
-   * occured and it can be obtained with error().  If the value hasValue(),
+   * occurred and it can be obtained with error().  If the value hasValue(),
    * indicates that peekCallback has been called.
    *
    * The range that is passed to callback is only valid until callback returns,
@@ -788,7 +788,7 @@ class QuicSocket {
    * Consumes data on the given stream, starting from currentReadOffset
    *
    * The return value is Expected.  If the value hasError(), then a read error
-   * occured and it can be obtained with error().
+   * occurred and it can be obtained with error().
    *
    * @offset - represents start of consumed range.
    * Current implementation returns error and currentReadOffset if offset !=

--- a/quic/api/QuicTransportBase.h
+++ b/quic/api/QuicTransportBase.h
@@ -438,7 +438,7 @@ class QuicTransportBase : public QuicSocket, QuicStreamPrioritiesObserver {
    * factor to use when in background mode.
    *
    * If all streams have equal or lower priority compares to the threshold
-   * (value >= threshold), the connection is considered to be in backround mode.
+   * (value >= threshold), the connection is considered to be in background mode.
    */
   void setBackgroundModeParameters(
       PriorityLevel maxBackgroundPriority,
@@ -905,7 +905,7 @@ class QuicTransportBase : public QuicSocket, QuicStreamPrioritiesObserver {
 
   // Priority level threshold for background streams
   // If all streams have equal or lower priority to the threshold
-  // (value >= threshold), the connection is considered to be in backround mode.
+  // (value >= threshold), the connection is considered to be in background mode.
   folly::Optional<PriorityLevel> backgroundPriorityThreshold_;
   folly::Optional<float> backgroundUtilizationFactor_;
 
@@ -967,7 +967,7 @@ class QuicTransportBase : public QuicSocket, QuicStreamPrioritiesObserver {
 
  private:
   /**
-   * Helper funtions to handle new streams.
+   * Helper functions to handle new streams.
    */
   void handleNewStreams(std::vector<StreamId>& newPeerStreams);
   void handleNewGroupedStreams(std::vector<StreamId>& newPeerStreams);

--- a/quic/api/QuicTransportFunctions.cpp
+++ b/quic/api/QuicTransportFunctions.cpp
@@ -1761,7 +1761,7 @@ void implicitAckCryptoStream(
         LOG(FATAL) << "Got loss from implicit crypto ACK.";
       },
       implicitAckTime);
-  // Clear our the loss buffer explicity. The implicit ACK itself will not
+  // Clear our the loss buffer explicitly. The implicit ACK itself will not
   // remove data already in the loss buffer.
   auto cryptoStream = getCryptoStream(*conn.cryptoState, encryptionLevel);
   cryptoStream->lossBuffer.clear();

--- a/quic/api/test/Mocks.h
+++ b/quic/api/test/Mocks.h
@@ -192,7 +192,7 @@ class MockQuicTransport : public QuicServerTransport {
         QuicServerTransport::Ptr transport,
         ConnectionId id) noexcept = 0;
 
-    // Called when a connecton id is bound and ip address should not
+    // Called when a connection id is bound and ip address should not
     // be used any more for routing.
     virtual void onConnectionIdBound(
         QuicServerTransport::Ptr transport) noexcept = 0;

--- a/quic/api/test/QuicTransportBaseTest.cpp
+++ b/quic/api/test/QuicTransportBaseTest.cpp
@@ -2056,7 +2056,7 @@ TEST_P(
   streamState->ackedIntervals.insert(0, 6);
 
   // Have 2 different recipients register for a callback on the same stream ID
-  // and offset that is before the curernt write offset, they will both be
+  // and offset that is before the current write offset, they will both be
   // scheduled for immediate delivery.
   EXPECT_CALL(txcb1, onByteEventRegistered(getTxMatcher(stream, 3)));
   EXPECT_CALL(txcb2, onByteEventRegistered(getTxMatcher(stream, 3)));
@@ -2092,7 +2092,7 @@ TEST_F(
   streamState->ackedIntervals.insert(0, 6);
 
   // Have 2 different recipients register for a callback on the same stream ID
-  // and offset that is before the curernt write offset, they will both be
+  // and offset that is before the current write offset, they will both be
   // scheduled for immediate delivery.
   EXPECT_CALL(txcb1, onByteEventRegistered(getAckMatcher(stream, 3)));
   EXPECT_CALL(txcb2, onByteEventRegistered(getAckMatcher(stream, 3)));
@@ -4234,7 +4234,7 @@ TEST_P(QuicTransportImplTestBase, BackgroundModeChangeWithStreamChanges) {
   conn.congestionController = std::move(mockCongestionController);
   auto& manager = *conn.streamManager;
   EXPECT_CALL(*rawCongestionController, setBandwidthUtilizationFactor(_))
-      .Times(0); // Backgound params not set
+      .Times(0); // Background params not set
   auto stream = manager.createNextUnidirectionalStream().value();
   manager.setStreamPriority(stream->id, Priority(1, false));
 

--- a/quic/api/test/QuicTransportFunctionsTest.cpp
+++ b/quic/api/test/QuicTransportFunctionsTest.cpp
@@ -672,7 +672,7 @@ TEST_F(
   auto buf2 = IOBuf::copyBuffer("?");
   writeDataToQuicStream(*stream3, buf->clone(), true /* eof */);
 
-  // packet2 contains orignally transmitted frames + new data frames
+  // packet2 contains originally transmitted frames + new data frames
   auto packet2 = buildEmptyPacket(*conn, PacketNumberSpace::AppData);
   packet2.packet.frames.push_back(writeStreamFrame1);
   packet2.packet.frames.push_back(writeStreamFrame2);

--- a/quic/api/test/QuicTransportTest.cpp
+++ b/quic/api/test/QuicTransportTest.cpp
@@ -1798,7 +1798,7 @@ TEST_F(QuicTransportTest, WriteFlowControl) {
       conn.transportSettings.writeConnectionDataPacketsLimit);
   verifyCorrectness(conn, 100, streamId, *buf1, false, false);
 
-  // Connection flow controled
+  // Connection flow controlled
   auto num_outstandings = conn.outstandings.packets.size();
   stream->flowControlState.peerAdvertisedMaxOffset = 300;
   conn.streamManager->updateWritableStreams(*stream);
@@ -4650,7 +4650,7 @@ TEST_F(QuicTransportTest, GetStreamPacketsTxedMultipleBytes) {
   Mock::VerifyAndClearExpectations(&firstByteTxCb);
   Mock::VerifyAndClearExpectations(&lastByteTxCb);
 
-  // when first and last byte TX callbacsk fired, numPacketsTxWithNewData should
+  // when first and last byte TX callback fired, numPacketsTxWithNewData should
   // be 1
   EXPECT_CALL(firstByteTxCb, onByteEvent(getTxMatcher(stream, 0)))
       .Times(1)

--- a/quic/client/QuicClientAsyncTransport.cpp
+++ b/quic/client/QuicClientAsyncTransport.cpp
@@ -41,7 +41,7 @@ void QuicClientAsyncTransport::onStopSending(
 void QuicClientAsyncTransport::onConnectionEnd() noexcept {
   folly::AsyncSocketException ex(
       folly::AsyncSocketException::UNKNOWN, "Quic connection ended");
-  // TODO: closeNow inside this callback may actually trigger gracefull close
+  // TODO: closeNow inside this callback may actually trigger graceful close
   closeNowImpl(std::move(ex));
 }
 
@@ -49,7 +49,7 @@ void QuicClientAsyncTransport::onConnectionError(QuicError error) noexcept {
   folly::AsyncSocketException ex(
       folly::AsyncSocketException::UNKNOWN,
       folly::to<std::string>("Quic connection error", error.message));
-  // TODO: closeNow inside this callback may actually trigger gracefull close
+  // TODO: closeNow inside this callback may actually trigger graceful close
   closeNowImpl(std::move(ex));
 }
 

--- a/quic/client/QuicClientTransport.cpp
+++ b/quic/client/QuicClientTransport.cpp
@@ -819,7 +819,7 @@ void QuicClientTransport::onReadData(
     const folly::SocketAddress& peer,
     NetworkDataSingle&& networkData) {
   if (closeState_ == CloseState::CLOSED) {
-    // If we are closed, then we shoudn't process new network data.
+    // If we are closed, then we shouldn't process new network data.
     QUIC_STATS(
         statsCallback_, onPacketDropped, PacketDropReason::CLIENT_STATE_CLOSED);
     if (conn_->qLogger) {

--- a/quic/client/handshake/ClientHandshake.h
+++ b/quic/client/handshake/ClientHandshake.h
@@ -53,7 +53,7 @@ class ClientHandshake : public Handshake {
   virtual void removePsk(const folly::Optional<std::string>& /* hostname */) {}
 
   /**
-   * Returns a reference to the CryptoFactory used internaly.
+   * Returns a reference to the CryptoFactory used internally.
    */
   virtual const CryptoFactory& getCryptoFactory() const = 0;
 

--- a/quic/client/state/ClientStateMachine.cpp
+++ b/quic/client/state/ClientStateMachine.cpp
@@ -68,8 +68,8 @@ std::unique_ptr<QuicClientConnectionState> undoAllClientStateForRetry(
   if (conn->congestionControllerFactory) {
     newConn->congestionControllerFactory = conn->congestionControllerFactory;
     if (conn->congestionController) {
-      // we have to recreate congestion controler
-      // because it holds referencs to the old state
+      // we have to recreate congestion controller
+      // because it holds references to the old state
       newConn->congestionController =
           newConn->congestionControllerFactory->makeCongestionController(
               *newConn, conn->congestionController->type());

--- a/quic/codec/Decode.h
+++ b/quic/codec/Decode.h
@@ -169,7 +169,7 @@ folly::Expected<ParsedLongHeaderInvariant, TransportErrorCode>
 parseLongHeaderInvariant(uint8_t initalByte, folly::io::Cursor& cursor);
 
 struct PacketLength {
-  // The length of the packet payload (inlcuding packet number)
+  // The length of the packet payload (including packet number)
   uint64_t packetLength;
   // Length of the length field.
   size_t lengthLength;

--- a/quic/codec/QuicPacketBuilder.h
+++ b/quic/codec/QuicPacketBuilder.h
@@ -42,7 +42,7 @@ class PacketBuilderInterface {
  public:
   virtual ~PacketBuilderInterface() = default;
 
-  // TODO: Temporarly let this interface be reusable across different concrete
+  // TODO: Temporarily let this interface be reusable across different concrete
   // builder types. But this isn't optimized for builder that writes both header
   // and body into a continuous memory.
   struct Packet {

--- a/quic/codec/QuicPacketRebuilder.h
+++ b/quic/codec/QuicPacketRebuilder.h
@@ -17,7 +17,7 @@ namespace quic {
  * pass them onto a wrapped builder to rebuild the packet. Note that you still
  * buildPacket() from the wrapped in builder.
  * TODO: The cloning builder only clones stream data that has not already been
- * resset or closed. It is possible that a packet may have contained data for
+ * reset or closed. It is possible that a packet may have contained data for
  * only closed streams. In that case we would only write out the header.
  * This is a waste, so we should do something about this in the future.
  */

--- a/quic/codec/QuicWriteCodec.cpp
+++ b/quic/codec/QuicWriteCodec.cpp
@@ -297,7 +297,7 @@ static size_t fillPacketReceiveTimestamps(
   }
   auto recvdPacketInfos = ackFrameMetaData.ackState.recvdPacketInfos;
   // Insert all received packet timestamps into an interval set, to identify
-  // continguous ranges
+  // contiguous ranges
 
   uint64_t pktsAdded = 0;
   IntervalSet<PacketNum> receivedPktNumsIntervalSet;
@@ -325,7 +325,7 @@ static size_t fillPacketReceiveTimestamps(
     } else {
       nextTimestampRange.gap = prevPktNum - 2 - timestampIntervalsIt->end;
     }
-    // Intialize spaced used by the next candidate time-stamp range
+    // Initialize spaced used by the next candidate time-stamp range
     nextTimestampRangeUsedSpace +=
         getQuicIntegerSizeThrows(nextTimestampRange.gap);
 

--- a/quic/codec/Types.h
+++ b/quic/codec/Types.h
@@ -243,7 +243,7 @@ struct WriteAckFrameState {
   // The maximum number of packets stored in pktsReceivedTimestamps is
   // controlled by kMaxReceivedPktsTimestampsStored.
   //
-  // The packet number of entries in the deque is guarenteed to increase
+  // The packet number of entries in the deque is guaranteed to increase
   // monotonically because an entry is only added for a received packet
   // if the packet number is greater than the packet number of the last
   // element in the deque (e.g., entries are not added for packets that

--- a/quic/codec/test/QuicPacketBuilderTest.cpp
+++ b/quic/codec/test/QuicPacketBuilderTest.cpp
@@ -29,7 +29,7 @@ Buf packetToBuf(
     RegularQuicPacketBuilder::Packet& packet,
     Aead* aead = nullptr) {
   auto buf = folly::IOBuf::create(0);
-  // This doesnt matter.
+  // This does not matter.
   PacketNum num = 10;
   if (packet.header) {
     buf->prependChain(packet.header->clone());

--- a/quic/codec/test/QuicWriteCodecTest.cpp
+++ b/quic/codec/test/QuicWriteCodecTest.cpp
@@ -579,7 +579,7 @@ TEST_F(QuicWriteCodecTest, WriteStreamSpaceForOneByte) {
   bool fin = false;
   // 1 byte for type
   // 1 byte for stream id
-  // 1 byte for offet
+  // 1 byte for offset
   // => 3 bytes
   auto dataLen = writeStreamFrameHeader(
       pktBuilder,

--- a/quic/common/BufUtil.h
+++ b/quic/common/BufUtil.h
@@ -109,7 +109,7 @@ class BufWriter {
   void push(const uint8_t* data, size_t len);
 
   /**
-   * Push len amound from data into the IOBuf, starting at IOBuf's destOffset
+   * Push len amount from data into the IOBuf, starting at IOBuf's destOffset
    * position. Given this is a back fill, we don't increase the written bytes
    * count for this API, since they should be already counted in a previous
    * append() call.

--- a/quic/common/test/BufUtilTest.cpp
+++ b/quic/common/test/BufUtilTest.cpp
@@ -490,7 +490,7 @@ TEST(BufWriterTest, IOBufChainCopyTooLargeLimit) {
       folly::IOBuf::copyBuffer("Think I'll take a turn from the known road. "));
   inputBuffer->prependChain(
       folly::IOBuf::copyBuffer("Think I'll write a tale of my own."));
-  // Use a limit thats larger than input size
+  // Use a limit that's larger than input size
   bufWriter.insert(
       inputBuffer.get(), inputBuffer->computeChainDataLength() * 3);
   folly::io::Cursor reader(outputBuffer.get());

--- a/quic/common/test/TestUtils.h
+++ b/quic/common/test/TestUtils.h
@@ -148,7 +148,7 @@ QuicCachedPsk setupZeroRttOnClientCtx(
 
 template <class T>
 std::unique_ptr<T> createNoOpAeadImpl(uint64_t cipherOverhead = 0) {
-  // Fake that the handshake has already occured
+  // Fake that the handshake has already occurred
   auto aead = std::make_unique<testing::NiceMock<T>>();
   ON_CALL(*aead, _inplaceEncrypt(testing::_, testing::_, testing::_))
       .WillByDefault(testing::Invoke([&](auto& buf, auto, auto) {
@@ -158,7 +158,7 @@ std::unique_ptr<T> createNoOpAeadImpl(uint64_t cipherOverhead = 0) {
           return folly::IOBuf::create(0);
         }
       }));
-  // Fake that the handshake has already occured and fix the keys.
+  // Fake that the handshake has already occurred and fix the keys.
   ON_CALL(*aead, _decrypt(testing::_, testing::_, testing::_))
       .WillByDefault(
           testing::Invoke([&](auto& buf, auto, auto) { return buf->clone(); }));

--- a/quic/congestion_control/Bbr.h
+++ b/quic/congestion_control/Bbr.h
@@ -22,7 +22,7 @@ constexpr float kStartupGain = 2.885f; // 2/ln(2)
 constexpr float kProbeBwGain = 2.0f;
 // The expected of bandwidth growth in each round trip time during STARTUP
 constexpr float kExpectedStartupGrowth = 1.25f;
-// How many rounds of rtt to stay in STARUP when the bandwidth isn't growing as
+// How many rounds of rtt to stay in STARTUP when the bandwidth isn't growing as
 // fast as kExpectedStartupGrowth
 constexpr uint8_t kStartupSlowGrowRoundLimit = 3;
 // Default number of pacing cycles

--- a/quic/congestion_control/Bbr2.cpp
+++ b/quic/congestion_control/Bbr2.cpp
@@ -588,7 +588,7 @@ bool Bbr2CongestionController::hasElapsedInPhase(
   return Clock::now() > probeBWCycleStart_ + interval;
 }
 
-// Was the loss percent too hight for the last ack received?
+// Was the loss percent too high for the last ack received?
 bool Bbr2CongestionController::checkInflightTooHigh(
     uint64_t inflightBytesAtLargestAckedPacket,
     uint64_t lostBytes) {

--- a/quic/congestion_control/BbrTesting.cpp
+++ b/quic/congestion_control/BbrTesting.cpp
@@ -32,7 +32,7 @@ BbrTestingCongestionController::BbrTestingCongestionController(
 
 // Limit the bandwidth based upon the measured TBF data.
 // If we have a simulated token bucket with probability>kProbabilityThreshold,
-// bandwdith estimate =
+// bandwidth estimate =
 // max(min(tbf_rate,long_term_bw_sampler_rate),short_term_sampler_rate)
 // This allows the returned bandwidth value to:
 // - Continue working normally when probability is low in any Token Bucket

--- a/quic/congestion_control/QuicCubic.cpp
+++ b/quic/congestion_control/QuicCubic.cpp
@@ -334,7 +334,7 @@ void Cubic::onPacketAckOrLoss(
   // TODO: current code in detectLossPackets only gives back a loss event when
   // largestLostPacketNum isn't a folly::none. But we should probably also check
   // against it here anyway just in case the loss code is changed in the
-  // furture.
+  // future.
   if (lossEvent) {
     onPacketLoss(*lossEvent);
     if (conn_.pacer) {
@@ -565,7 +565,7 @@ void Cubic::onPacketAckedInHystart(const AckEvent& ack) {
  * algorithm as well, "time to origin" is the time it takes to grow cwnd back to
  * Wmax from its current value. Chromium follows Linux implementation. It
  * affects timeElapsed as well. If we want to follow the Linux/Chromium
- * implemetation, then
+ * implementation, then
  *    timeElapsed = now() - time of the first Ack since last window reduction.
  * Alternatively, the paper's definition,
  *    timeElapsed = now() - time of last window reduction.

--- a/quic/congestion_control/test/BbrTest.cpp
+++ b/quic/congestion_control/test/BbrTest.cpp
@@ -72,7 +72,7 @@ TEST_F(BbrTest, Recovery) {
   inflightBytes -= (loss.lostBytes + ackedBytes);
   uint64_t expectedRecoveryWindow = std::max(
       inflightBytes + ackedBytes - loss.lostBytes, inflightBytes + ackedBytes);
-  // This sets the connectin to recovery state, also sets both the
+  // This sets the connection to recovery state, also sets both the
   // endOfRoundTrip_ and endOfRecovery_ to Clock::now()
   bbr.onPacketAckOrLoss(
       makeAck(0, ackedBytes, Clock::now(), Clock::now() - 5ms), loss);

--- a/quic/fizz/client/test/QuicClientTransportTest.cpp
+++ b/quic/fizz/client/test/QuicClientTransportTest.cpp
@@ -4176,7 +4176,7 @@ TEST_F(QuicClientTransportAfterStartTest, SendReset) {
 
   const auto& readCbs = client->getReadCallbacks();
   const auto& conn = client->getConn();
-  // ReadCallbacks are not affected by reseting send state
+  // ReadCallbacks are not affected by resetting send state
   EXPECT_EQ(1, readCbs.count(streamId));
   // readable list can still be populated after a reset.
   EXPECT_FALSE(writableContains(*conn.streamManager, streamId));
@@ -4267,7 +4267,7 @@ TEST_F(QuicClientTransportAfterStartTest, SendResetAfterEom) {
   verifyShortPackets(sentPackets);
   const auto& readCbs = client->getReadCallbacks();
   const auto& conn = client->getConn();
-  // ReadCallback are not affected by reseting send state.
+  // ReadCallback are not affected by resetting send state.
   EXPECT_EQ(1, readCbs.count(streamId));
   // readable list can still be populated after a reset.
   EXPECT_FALSE(writableContains(*conn.streamManager, streamId));

--- a/quic/fizz/client/test/QuicClientTransportTestUtil.h
+++ b/quic/fizz/client/test/QuicClientTransportTestUtil.h
@@ -510,7 +510,7 @@ class QuicClientTransportTestBase : public virtual testing::Test {
   }
 
   virtual void setupCryptoLayer() {
-    // Fake that the handshake has already occured and fix the keys.
+    // Fake that the handshake has already occurred and fix the keys.
     mockClientHandshake = new FakeOneRttHandshakeLayer(
         &client->getNonConstConn(), getFizzClientContext());
     client->getNonConstConn().clientHandshakeLayer = mockClientHandshake;

--- a/quic/handshake/CryptoFactory.h
+++ b/quic/handshake/CryptoFactory.h
@@ -49,7 +49,7 @@ class CryptoFactory {
       QuicVersion version) const;
 
   /**
-   * Crypto layer specifc methods.
+   * Crypto layer specific methods.
    */
   virtual Buf makeInitialTrafficSecret(
       folly::StringPiece label,

--- a/quic/loss/test/QuicLossFunctionsTest.cpp
+++ b/quic/loss/test/QuicLossFunctionsTest.cpp
@@ -1062,7 +1062,7 @@ TEST_F(QuicLossFunctionsTest, LossTimePreemptsCryptoTimer) {
       folly::chrono::ceil<std::chrono::milliseconds>(expectedDelayUntilLost),
       alarm.first);
   EXPECT_EQ(LossState::AlarmMethod::EarlyRetransmitOrReordering, alarm.second);
-  // Manual set lossState. Calling setLossDetectionAlarm requries a Timeout
+  // Manual set lossState. Calling setLossDetectionAlarm requires a Timeout
   conn->lossState.currentAlarmMethod = alarm.second;
 
   // Second packet gets acked:
@@ -2444,7 +2444,7 @@ TEST_F(QuicLossFunctionsTest, LossVisitorDSRTest) {
   EXPECT_FALSE(conn->streamManager->writableDSRStreams().contains(stream->id));
   EXPECT_TRUE(conn->streamManager->writeQueue().count(stream->id));
 
-  // Lose the 3nd dsr packet, it should be merged together with the first
+  // Lose the 3rd dsr packet, it should be merged together with the first
   // element in the lossBufMetas:
   RegularQuicWritePacket packet2(PacketHeader(ShortHeader(
       ProtectionType::KeyPhaseZero, conn->serverConnectionId.value(), 2)));

--- a/quic/observer/SocketObserverInterface.cpp
+++ b/quic/observer/SocketObserverInterface.cpp
@@ -127,7 +127,7 @@ void SocketObserverInterface::PacketsWrittenEvent::
   }
 
   // The packets in the OutstandingPackets deque are sorted by their sequence
-  // nunber in their packet number space. As a result, the N packets at the end
+  // number in their packet number space. As a result, the N packets at the end
   // of the deque may not be the N most recently sent OutstandingPacketss.
   // Furthermore, adjacent OutstandingPackets may have the same sequence
   // number because they belong to different packet number spaces. Because

--- a/quic/observer/SocketObserverInterface.h
+++ b/quic/observer/SocketObserverInterface.h
@@ -471,7 +471,7 @@ class SocketObserverInterface {
       folly::EventBase* /* evb */) noexcept {}
 
   /**
-   * startWritingFromAppLimited() is invoked when the socket is currenty
+   * startWritingFromAppLimited() is invoked when the socket is currently
    * app rate limited and is being given an opportunity to write packets.
    *
    * @param socket   Socket that is starting to write from an app limited state.

--- a/quic/server/QuicServer.cpp
+++ b/quic/server/QuicServer.cpp
@@ -478,7 +478,7 @@ void QuicServer::shutdown(LocalErrorCode error) {
       workerPtr_.reset();
     });
     // protecting the erase in map with the mutex since
-    // the erase could potentally affect concurrent accesses from other threads
+    // the erase could potentially affect concurrent accesses from other threads
     std::lock_guard<std::mutex> guard(startMutex_);
     evbToWorkers_.erase(worker->getEventBase());
   }

--- a/quic/server/QuicServer.h
+++ b/quic/server/QuicServer.h
@@ -462,7 +462,7 @@ class QuicServer : public QuicServerWorker::WorkerCallback,
   QuicAsyncUDPSocketType::BindOptions bindOptions_;
 
   // set by getEventBaseBackend if multishot callback is
-  // supprted
+  // supported
   bool backendSupportsMultishotCallback_{false};
 };
 

--- a/quic/server/QuicServerPacketRouter.cpp
+++ b/quic/server/QuicServerPacketRouter.cpp
@@ -118,7 +118,7 @@ void TakeoverHandlerCallback::onReadClosed() noexcept {
   //  If we delete the socket in the callback of close, then this might cause
   //  some reentrancy in deletion, since close() in AsyncUDPSocket doesn't
   //  guard itself against deletion in the onReadClosed() callback.
-  //  Doing nothing since the ASyncUDPSocket will implictly pause the reads.
+  //  Doing nothing since the ASyncUDPSocket will implicitly pause the reads.
 }
 
 void TakeoverPacketHandler::setDestination(

--- a/quic/server/QuicServerTransport.cpp
+++ b/quic/server/QuicServerTransport.cpp
@@ -522,7 +522,7 @@ void QuicServerTransport::processPendingData(bool async) {
         }
         // The app could have triggered a graceful close from the callbacks,
         // in which case we should continue with the handshake and processing
-        // the reamining data because it could potentially have a FIN which
+        // the remaining data because it could potentially have a FIN which
         // could end the graceful close.
       }
     };
@@ -786,7 +786,7 @@ void QuicServerTransport::registerAllTransportKnobParamHandlers() {
         auto val = std::get<uint64_t>(value);
 
         // Check if the server should process this knob, i.e should set the max
-        // pacing rate to the given value. Currently there is a possiblity that
+        // pacing rate to the given value. Currently there is a possibility that
         // MAX_PACING_RATE_KNOB frames arrive out of order, causing incorrect
         // max pacing rate to be set on the transport, i.e. the rate is set to a
         // low value when it should be set to max value (i.e. disabled pacing).

--- a/quic/server/QuicServerTransport.h
+++ b/quic/server/QuicServerTransport.h
@@ -51,7 +51,7 @@ class QuicServerTransport
         Ref transport,
         ConnectionId id) noexcept = 0;
 
-    // Called when a connecton id is bound and ip address should not
+    // Called when a connection id is bound and ip address should not
     // be used any more for routing.
     virtual void onConnectionIdBound(Ptr transport) noexcept = 0;
 

--- a/quic/server/QuicServerWorker.cpp
+++ b/quic/server/QuicServerWorker.cpp
@@ -581,7 +581,7 @@ void QuicServerWorker::forwardNetworkData(
     folly::Optional<QuicVersion> quicVersion,
     bool isForwardedData) {
   // if it's not Client initial or ZeroRtt, AND if the connectionId version
-  // mismatches: foward if pktForwarding is enabled else dropPacket
+  // mismatches: forward if pktForwarding is enabled else dropPacket
   if (!routingData.clientChosenDcid &&
       !connIdAlgo_->canParse(routingData.destinationConnId)) {
     if (packetForwardingEnabled_ && !isForwardedData) {
@@ -1011,7 +1011,7 @@ bool QuicServerWorker::validRetryToken(
 
   TokenGenerator tokenGenerator(transportSettings_.retryTokenSecret.value());
 
-  // Create a psuedo token to generate the assoc data.
+  // Create a pseudo token to generate the assoc data.
   RetryToken token(dstConnId, clientIp, 0);
 
   auto maybeDecryptedRetryTokenMs = tokenGenerator.decryptToken(
@@ -1028,7 +1028,7 @@ bool QuicServerWorker::validNewToken(
 
   TokenGenerator tokenGenerator(transportSettings_.retryTokenSecret.value());
 
-  // Create a psuedo token to generate the assoc data.
+  // Create a pseudo token to generate the assoc data.
   NewToken token(clientIp);
 
   auto maybeDecryptedNewTokenMs = tokenGenerator.decryptToken(
@@ -1071,7 +1071,7 @@ void QuicServerWorker::sendRetryPacket(
       initialByte,
       dstConnId, /* src conn id */
       srcConnId, /* dst conn id */
-      dstConnId, /* orginal dst conn id */
+      dstConnId, /* original dst conn id */
       QuicVersion::MVFST_INVALID,
       folly::IOBuf::copyBuffer(encryptedTokenStr));
   Buf pseudoRetryPacketBuf = std::move(pseudoBuilder).buildPacket();

--- a/quic/server/QuicServerWorker.h
+++ b/quic/server/QuicServerWorker.h
@@ -377,7 +377,7 @@ class QuicServerWorker : public QuicAsyncUDPSocketWrapper::ReadCallback,
 
   // Routing callback
   /**
-   * Called when a connecton id is available for a new connection (i.e flow)
+   * Called when a connection id is available for a new connection (i.e flow)
    * The connection-id here is chosen by this server
    */
   void onConnectionIdAvailable(
@@ -393,7 +393,7 @@ class QuicServerWorker : public QuicAsyncUDPSocketWrapper::ReadCallback,
       ConnectionId id) noexcept override;
 
   /**
-   * Called when a connecton id is bound and ip address should not
+   * Called when a connection id is bound and ip address should not
    * be used any more for routing.
    */
   void onConnectionIdBound(

--- a/quic/server/handshake/ServerHandshake.h
+++ b/quic/server/handshake/ServerHandshake.h
@@ -102,7 +102,7 @@ class ServerHandshake : public Handshake {
   virtual void writeNewSessionTicket(const AppToken& appToken);
 
   /**
-   * Returns a reference to the CryptoFactory used internaly.
+   * Returns a reference to the CryptoFactory used internally.
    */
   virtual const CryptoFactory& getCryptoFactory() const = 0;
 
@@ -178,7 +178,7 @@ class ServerHandshake : public Handshake {
   const fizz::server::State& getState() const;
 
   /**
-   * Retuns the negotiated ALPN from the handshake.
+   * Returns the negotiated ALPN from the handshake.
    */
   const folly::Optional<std::string>& getApplicationProtocol() const override;
 

--- a/quic/server/state/ServerStateMachine.cpp
+++ b/quic/server/state/ServerStateMachine.cpp
@@ -1385,7 +1385,7 @@ void onServerReadDataFromClosed(
   }
 
   if (conn.peerConnectionError) {
-    // We already got a peer error. We can ignore any futher peer errors.
+    // We already got a peer error. We can ignore any further peer errors.
     if (conn.qLogger) {
       conn.qLogger->addPacketDrop(
           packetSize,

--- a/quic/server/test/QuicServerTransportTest.cpp
+++ b/quic/server/test/QuicServerTransportTest.cpp
@@ -4692,7 +4692,7 @@ TEST_F(QuicServerTransportTest, TestRegisterAndHandleTransportKnobParams) {
 
   EXPECT_EQ(flag, 1);
 
-  // ovewrite will fail, the new handler won't be called
+  // overwrite will fail, the new handler won't be called
   server->registerKnobParamHandler(
       199,
       [&](QuicServerTransport* /* server_conn */, TransportKnobParam::Val val) {

--- a/quic/state/AckStates.h
+++ b/quic/state/AckStates.h
@@ -41,7 +41,7 @@ struct AckState : WriteAckFrameState {
   // ack for the first time.
   // - the peer has requested it through an immediate ack frame.
   bool needsToSendAckImmediately{false};
-  // Count of oustanding packets received with retransmittable data.
+  // Count of outstanding packets received with retransmittable data.
   uint8_t numRxPacketsRecvd{0};
   // Receive time of the latest packet
   folly::Optional<TimePoint> latestRecvdPacketTime;

--- a/quic/state/OutstandingPacket.h
+++ b/quic/state/OutstandingPacket.h
@@ -45,7 +45,7 @@ struct OutstandingPacketMetadata {
   // Cmsgs added by the QuicSocket when this packet was written
   folly::Optional<folly::SocketOptionMap> cmsgs;
 
-  // Has value if the packet is lost by timout. The value is the loss timeout
+  // Has value if the packet is lost by timeout. The value is the loss timeout
   // dividend that was used to declare this packet.
   folly::Optional<DurationRep> lossTimeoutDividend;
 

--- a/quic/state/QuicStateFunctions.cpp
+++ b/quic/state/QuicStateFunctions.cpp
@@ -181,7 +181,7 @@ void updateAckSendStateOnSentPacketWithAcks(
   // When we send an ack we're most likely going to ack the largest received
   // packet, so reset the counters for numRxPacketsRecvd and
   // numNonRxPacketsRecvd. Since our ack threshold is quite small, we make the
-  // critical assumtion here that that all the needed acks can fit into one
+  // critical assumption here that that all the needed acks can fit into one
   // packet if needed. If this is not the case, then some packets may not get
   // acked as a result and the receiver might retransmit them.
   ackState.numRxPacketsRecvd = 0;

--- a/quic/state/QuicStreamFunctions.h
+++ b/quic/state/QuicStreamFunctions.h
@@ -90,7 +90,7 @@ bool allBytesTillFinAcked(const QuicStreamState& state);
 
 /**
  * Add a pending reset for stream into conn's pendingEvents if the stream isn't
- * in WaitingForRstAck or Closed state alraedy
+ * in WaitingForRstAck or Closed state already
  */
 void appendPendingStreamReset(
     QuicConnectionStateBase& conn,

--- a/quic/state/QuicStreamManager.cpp
+++ b/quic/state/QuicStreamManager.cpp
@@ -44,7 +44,7 @@ static void updateHolBlockedTime(QuicStreamState& stream) {
     return;
   }
 
-  // No HOL unblocking event has occured. If we are already HOL bloked,
+  // No HOL unblocking event has occurred. If we are already HOL blocked,
   // we remain HOL blocked.
   if (stream.lastHolbTime) {
     return;

--- a/quic/state/StateData.h
+++ b/quic/state/StateData.h
@@ -165,7 +165,7 @@ class AppLimitedTracker {
   }
 
   /**
-   * Returns whether the connection has been marked as appplication limited.
+   * Returns whether the connection has been marked as application limited.
    */
   bool isAppLimited() {
     return isAppLimited_;
@@ -222,7 +222,7 @@ struct Pacer {
    * - If the pacer is currently using a faster pace, it will be brought down to
    *   maxRateBytesPerSec.
    * - If refreshPacingRate or setPacingRate are called with a value
-   * greated than maxRateBytesPerSec, maxRateBytesPerSec will be used instead.
+   * greater than maxRateBytesPerSec, maxRateBytesPerSec will be used instead.
    */
   virtual void setMaxPacingRate(uint64_t maxRateBytesPerSec) = 0;
 
@@ -618,12 +618,12 @@ struct QuicConnectionStateBase : public folly::DelayedDestruction {
 
   std::shared_ptr<LoopDetectorCallback> loopDetectorCallback;
 
-  // Measure rtt betwen pathchallenge & path response frame
+  // Measure rtt between pathchallenge & path response frame
   // Use this measured rtt as init rtt (from Transport Settings)
   TimePoint pathChallengeStartTime;
 
   /**
-   * Eary data app params functions.
+   * Eerie data app params functions.
    */
   folly::Function<bool(const folly::Optional<std::string>&, const Buf&) const>
       earlyDataAppParamsValidator;

--- a/quic/state/StreamData.h
+++ b/quic/state/StreamData.h
@@ -339,9 +339,9 @@ struct QuicStreamState : public QuicStreamLike {
 
   StreamFlowControlState flowControlState;
 
-  // Stream level read error occured.
+  // Stream level read error occurred.
   folly::Optional<QuicErrorCode> streamReadError;
-  // Stream level write error occured.
+  // Stream level write error occurred.
   folly::Optional<QuicErrorCode> streamWriteError;
 
   // State machine data
@@ -471,7 +471,7 @@ struct QuicStreamState : public QuicStreamLike {
 
   std::unique_ptr<DSRPacketizationRequestSender> dsrSender;
 
-  // BufferMeta that has been writen to the QUIC layer.
+  // BufferMeta that has been written to the QUIC layer.
   // When offset is 0, nothing has been written to it. On first write, its
   // starting offset will be currentWriteOffset + writeBuffer.chainLength().
   WriteBufferMeta writeBufMeta;

--- a/quic/state/stream/StreamStateFunctions.h
+++ b/quic/state/stream/StreamStateFunctions.h
@@ -14,7 +14,7 @@ namespace quic {
 // Common operations to conduct on QuicStreamState when send reset on it
 void resetQuicStream(QuicStreamState& stream, ApplicationErrorCode error);
 
-// Comon operations to conduct on QuicStreamState when receive reset on it
+// Common operations to conduct on QuicStreamState when receive reset on it
 void onResetQuicStream(QuicStreamState& stream, const RstStreamFrame& frame);
 
 bool isAllDataReceived(const QuicStreamState& stream);

--- a/quic/state/stream/test/StreamStateMachineTest.cpp
+++ b/quic/state/stream/test/StreamStateMachineTest.cpp
@@ -118,7 +118,7 @@ TEST_F(QuicOpenStateTest, ReceiveStreamFrameWithFINReadbuffHole) {
   auto stream = conn->streamManager->createNextBidirectionalStream().value();
   stream->currentReadOffset = 100;
 
-  // We received FIN, but we havn't received anything between 100 and 200:
+  // We received FIN, but we haven't received anything between 100 and 200:
   ReadStreamFrame receivedStreamFrame(stream->id, 200, true);
   receivedStreamFrame.data = folly::IOBuf::create(10);
   receivedStreamFrame.data->append(10);
@@ -341,7 +341,7 @@ TEST_F(QuicHalfClosedLocalStateTest, ReceiveStreamFrameWithFINReadbuffHole) {
   stream->recvState = StreamRecvState::Open;
   stream->currentReadOffset = 100;
 
-  // We received FIN, but we havn't received anything between 100 and 200:
+  // We received FIN, but we haven't received anything between 100 and 200:
   ReadStreamFrame receivedStreamFrame(stream->id, 200, true);
   receivedStreamFrame.data = folly::IOBuf::create(10);
   receivedStreamFrame.data->append(10);

--- a/quic/state/test/QuicStreamManagerTest.cpp
+++ b/quic/state/test/QuicStreamManagerTest.cpp
@@ -777,7 +777,7 @@ class QuicStreamManagerGroupsTest : public QuicStreamManagerTest {
 TEST_P(QuicStreamManagerGroupsTest, TestStreamGroupLimits) {
   auto& manager = *conn.streamManager;
 
-  // By default, no group creation hapenning.
+  // By default, no group creation happening.
   auto groupId = createNextStreamGroup();
   EXPECT_FALSE(groupId.hasValue());
   EXPECT_EQ(getNumGroups(), 0);

--- a/quic/tools/tperf/tperf.cpp
+++ b/quic/tools/tperf/tperf.cpp
@@ -48,7 +48,7 @@ DEFINE_bool(gso, true, "Enable GSO writes to the socket");
 DEFINE_uint32(
     client_transport_timer_resolution_ms,
     1,
-    "Timer resolution for Ack and Loss tiemout in client transport");
+    "Timer resolution for Ack and Loss timeout in client transport");
 DEFINE_string(
     server_qlogger_path,
     "",


### PR DESCRIPTION
`codespell --ignore-words-list=arithmetics,atleast,crate,crated,deriver,ect,hel,onl,startin,whats --skip="*.lock"`
* https://pypi.org/project/codespell